### PR TITLE
Set title and description also to the view.spec

### DIFF
--- a/SpatialDataPackageExport/core/datapackage.py
+++ b/SpatialDataPackageExport/core/datapackage.py
@@ -52,6 +52,8 @@ class DatapackageWriter:
         snapshot.name = snapshot_name
         snapshot.title = snapshot_config.title
         snapshot.views[0].spec.bounds = snapshot_config.bounds
+        snapshot.views[0].spec.title = snapshot_config.title
+        snapshot.views[0].spec.description = snapshot_config.description
         snapshot.description = snapshot_config.description
         snapshot.keywords = snapshot_config.keywords
         snapshot.sources = snapshot_config.sources

--- a/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
+++ b/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
@@ -1,0 +1,244 @@
+{
+  "name": "simple-poly",
+  "title": "test title",
+  "description": "test description",
+  "version": "1.0.0",
+  "datapackage_version": "1.0.0",
+  "gemeindescan_version": "0.3.1",
+  "gemeindescan_meta": {
+    "topic": "GEMEINDESCAN TOPIC"
+  },
+  "format": "geojson",
+  "license": "ODC-By-1.0",
+  "licenses": [
+    {
+      "url": "https://opendatacommons.org/licenses/by/1.0/",
+      "type": "ODC-By-1.0"
+    }
+  ],
+  "keywords": [
+    "KEYWORD 1",
+    "KEYWORD 2"
+  ],
+  "views": [
+    {
+      "name": "mapview",
+      "specType": "gemeindescanSnapshot",
+      "spec": {
+        "title": "test title",
+        "description": "test description",
+        "attribution": "",
+        "bounds": [
+          "geo:8.35507485,47.06690836",
+          "geo:8.37991615,47.07424457"
+        ],
+        "legend": [
+          {
+            "label": "1",
+            "size": 1,
+            "shape": "rectangle",
+            "primary": false,
+            "fillColor": "#ec1182",
+            "fillOpacity": 1.0,
+            "strokeColor": "#232323",
+            "strokeWidth": 0.26,
+            "strokeOpacity": 1.0
+          },
+          {
+            "label": "2",
+            "size": 1,
+            "shape": "rectangle",
+            "primary": false,
+            "fillColor": "#3df091",
+            "fillOpacity": 1.0,
+            "strokeColor": "#232323",
+            "strokeWidth": 0.26,
+            "strokeOpacity": 1.0
+          },
+          {
+            "label": "3",
+            "size": 1,
+            "shape": "rectangle",
+            "primary": false,
+            "fillColor": "#4b50e2",
+            "fillOpacity": 1.0,
+            "strokeColor": "#232323",
+            "strokeWidth": 0.26,
+            "strokeOpacity": 1.0
+          },
+          {
+            "label": "",
+            "size": 1,
+            "shape": "rectangle",
+            "primary": false,
+            "fillColor": "#cecd73",
+            "fillOpacity": 1.0,
+            "strokeColor": "#232323",
+            "strokeWidth": 0.26,
+            "strokeOpacity": 1.0
+          }
+        ]
+      },
+      "resources": [
+        "asd",
+        "mapbox-background"
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "url": "SOURCE URL",
+      "title": "SOURCE TITLE/DESCRIPTION"
+    }
+  ],
+  "resources": [
+    {
+      "name": "asd",
+      "mediatype": "application/geo+json",
+      "data": {
+        "type": "FeatureCollection",
+        "name": "asd",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
+          }
+        },
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "fid": 1,
+              "asd": 1,
+              "fill": "#ec1182",
+              "fill-opacity": 1.0,
+              "stroke": "#232323",
+              "stroke-opacity": 1.0,
+              "stroke-width": 0.26
+            },
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    25.7164,
+                    60.7097
+                  ],
+                  [
+                    26.1841,
+                    60.543
+                  ],
+                  [
+                    25.6994,
+                    60.5148
+                  ],
+                  [
+                    25.6994,
+                    60.5148
+                  ],
+                  [
+                    25.7164,
+                    60.7097
+                  ]
+                ]
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "fid": 2,
+              "asd": 2,
+              "fill": "#3df091",
+              "fill-opacity": 1.0,
+              "stroke": "#232323",
+              "stroke-opacity": 1.0,
+              "stroke-width": 0.26
+            },
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    25.6056,
+                    60.4003
+                  ],
+                  [
+                    25.7168,
+                    60.2838
+                  ],
+                  [
+                    25.3571,
+                    60.288
+                  ],
+                  [
+                    25.6056,
+                    60.4003
+                  ]
+                ]
+              ]
+            }
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "fid": 3,
+              "asd": 3,
+              "fill": "#4b50e2",
+              "fill-opacity": 1.0,
+              "stroke": "#232323",
+              "stroke-opacity": 1.0,
+              "stroke-width": 0.26
+            },
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    24.6498,
+                    60.5776
+                  ],
+                  [
+                    24.9582,
+                    60.5258
+                  ],
+                  [
+                    24.7483,
+                    60.348
+                  ],
+                  [
+                    24.4788,
+                    60.4446
+                  ],
+                  [
+                    24.6498,
+                    60.5776
+                  ]
+                ]
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "mapbox-background",
+      "mediatype": "application/vnd.mapbox-vector-tile",
+      "path": "mapbox://styles/gemeindescan/ck6rp249516tg1iqkmt48o4pz"
+    }
+  ],
+  "maintainers": [
+    {
+      "web": "https://github.com/n0rdlicht/",
+      "name": "Thorben Westerhuys"
+    }
+  ],
+  "contributors": [
+    {
+      "web": "https://cividi.ch",
+      "role": "publisher",
+      "email": "info@cividi.ch",
+      "title": "cividi"
+    }
+  ]
+}

--- a/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
+++ b/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
@@ -27,8 +27,8 @@
       "name": "mapview",
       "specType": "gemeindescanSnapshot",
       "spec": {
-        "title": "",
-        "description": "",
+        "title": "Point Sample",
+        "description": "Points with radii.",
         "attribution": "",
         "bounds": [
           "geo:47.35694079,8.50916232",

--- a/SpatialDataPackageExport/test/test_datapackage.py
+++ b/SpatialDataPackageExport/test/test_datapackage.py
@@ -47,8 +47,10 @@ def test_categorized_poly(new_project, categorized_poly, layer_empty_poly):
     snapshot_config = config.snapshots[0]
     name = list(snapshot_config.keys())[0]
     snapshot_config = list(snapshot_config.values())[0]
+    snapshot_config.description = 'test description'
+    snapshot_config.title = 'test title'
     snapshot = writer.create_snapshot(name, snapshot_config, [styled_layer])
-    expected_snapshot_dict = get_test_json('snapshots', 'categorized_poly.json')
+    expected_snapshot_dict = get_test_json('snapshots', 'categorized_poly_custom_config.json')
     assert snapshot.to_dict() == expected_snapshot_dict
 
 


### PR DESCRIPTION
This PR resolves #13 by adding title and description to the `view.spec` in addition to `name` and `description` root fields.