### PR TITLE
Add setting to decide whether to add snapshot layers to the map

### DIFF
--- a/SpatialDataPackageExport/definitions/configurable_settings.py
+++ b/SpatialDataPackageExport/definitions/configurable_settings.py
@@ -26,13 +26,20 @@ from ..qgis_plugin_tools.tools.settings import get_setting, set_setting
 
 
 @enum.unique
+class LayerFormatOptions(enum.Enum):
+    memory = 'memory'
+    geojson = 'geojson'
+    none = 'none'
+
+
+@enum.unique
 class Settings(enum.Enum):
     extent_precision = 8
     export_config_template = resources_path('templates', 'export-config.json')
     snapshot_template = resources_path('templates', 'snapshot-template.json')
     layer_format = 'memory'
 
-    _options = {'layer_format': ['memory', 'geojson', 'none']}
+    _options = {'layer_format': [option.value for option in LayerFormatOptions]}
 
     def get(self, typehint: type = str) -> any:
         """Gets the value of the setting"""

--- a/SpatialDataPackageExport/definitions/configurable_settings.py
+++ b/SpatialDataPackageExport/definitions/configurable_settings.py
@@ -17,8 +17,12 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SpatialDataPackageExport.  If not, see <https://www.gnu.org/licenses/>.
 import enum
+from typing import Union, List
 
+from ..qgis_plugin_tools.tools.exceptions import QgsPluginException
+from ..qgis_plugin_tools.tools.i18n import tr
 from ..qgis_plugin_tools.tools.resources import resources_path
+from ..qgis_plugin_tools.tools.settings import get_setting, set_setting
 
 
 @enum.unique
@@ -26,3 +30,21 @@ class Settings(enum.Enum):
     extent_precision = 8
     export_config_template = resources_path('templates', 'export-config.json')
     snapshot_template = resources_path('templates', 'snapshot-template.json')
+    layer_format = 'memory'
+
+    _options = {'layer_format': ['memory', 'geojson', 'none']}
+
+    def get(self, typehint: type = str) -> any:
+        """Gets the value of the setting"""
+        return get_setting(self.name, self.value, typehint)
+
+    def set(self, value: Union[str, int, float, bool]) -> None:
+        """Sets the value of the setting"""
+        options = self.get_options()
+        if options and value not in options:
+            raise QgsPluginException(tr('Invalid option. Choose something from values {}', options))
+        set_setting(self.name, value)
+
+    def get_options(self) -> List[any]:
+        """Get options for the setting"""
+        return Settings._options.value.get(self.name, [])

--- a/SpatialDataPackageExport/model/styled_layer.py
+++ b/SpatialDataPackageExport/model/styled_layer.py
@@ -17,8 +17,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SpatialDataPackageExport.  If not, see <https://www.gnu.org/licenses/>.
 import json
-import os
 import tempfile
+from pathlib import Path
 from typing import List, Dict, Union
 
 from qgis.core import QgsVectorFileWriter, QgsCoordinateReferenceSystem, QgsProject
@@ -47,10 +47,14 @@ class StyledLayer:
                 data = json.load(f)
         else:
             with tempfile.TemporaryDirectory(dir=resources_path()) as tmpdirname:
-                f_name = os.path.join(tmpdirname, f'{self.resource_name}.geojson')
-                _writer = QgsVectorFileWriter.writeAsVectorFormat(self.layer, f_name, "utf-8",
-                                                                  QgsCoordinateReferenceSystem("EPSG:4326"),
-                                                                  driverName="GeoJSON")
-                with open(f_name) as f:
+                output_file = self.save_as_geojson(Path(tmpdirname))
+                with open(output_file) as f:
                     data = json.load(f)
         return data
+
+    def save_as_geojson(self, output_path: Path) -> Path:
+        output_file = Path(output_path, f'{self.resource_name}.geojson')
+        _writer = QgsVectorFileWriter.writeAsVectorFormat(self.layer, str(output_file), "utf-8",
+                                                          QgsCoordinateReferenceSystem("EPSG:4326"),
+                                                          driverName="GeoJSON")
+        return output_file

--- a/SpatialDataPackageExport/resources/ui/main_dialog_dock.ui
+++ b/SpatialDataPackageExport/resources/ui/main_dialog_dock.ui
@@ -17,7 +17,7 @@
          <set>QDockWidget::AllDockWidgetFeatures</set>
      </property>
      <property name="windowTitle">
-         <string>Gemeindescan Exporter</string>
+         <string>Spatial Data Package Export</string>
      </property>
      <widget class="QWidget" name="dockWidgetContents">
          <layout class="QVBoxLayout" name="verticalLayout">
@@ -227,7 +227,8 @@
                                      </property>
                                      <layout class="QGridLayout" name="gridLayout">
                                          <item row="3" column="1">
-                                             <layout class="QGridLayout" name="source_grid" columnminimumwidth="0,150,0">
+                                             <layout class="QGridLayout" name="source_grid"
+                                                     columnminimumwidth="0,150,0">
                                                  <item row="0" column="1">
                                                      <widget class="QLabel" name="label_3">
                                                          <property name="text">
@@ -378,16 +379,16 @@
                      </widget>
                  </widget>
              </item>
-    <item>
-     <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
-      <property name="font">
-       <font>
-        <weight>75</weight>
-        <bold>true</bold>
-       </font>
-      </property>
-      <property name="title">
-       <string>About</string>
+             <item>
+                 <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+                     <property name="font">
+                         <font>
+                             <weight>75</weight>
+                             <bold>true</bold>
+                         </font>
+                     </property>
+                     <property name="title">
+                         <string>About</string>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>

--- a/SpatialDataPackageExport/resources/ui/main_dialog_dock.ui
+++ b/SpatialDataPackageExport/resources/ui/main_dialog_dock.ui
@@ -2,348 +2,382 @@
 <ui version="4.0">
  <class>GsExporterDockWidgetBase</class>
  <widget class="QDockWidget" name="GsExporterDockWidgetBase">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>692</width>
-    <height>667</height>
-   </rect>
-  </property>
-  <property name="floating">
-   <bool>false</bool>
-  </property>
-  <property name="windowTitle">
-   <string>Gemeindescan Exporter</string>
-  </property>
-  <widget class="QWidget" name="dockWidgetContents">
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QScrollArea" name="scrollArea">
-      <property name="widgetResizable">
-       <bool>true</bool>
-      </property>
-      <widget class="QWidget" name="scrollAreaWidgetContents_2">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>658</width>
-         <height>502</height>
-        </rect>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_10">
-        <item>
-         <widget class="QgsCollapsibleGroupBox" name="mGroupBox_3">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="title">
-           <string>Export settings</string>
-          </property>
-          <property name="flat">
-           <bool>false</bool>
-          </property>
-          <property name="collapsed">
-           <bool>false</bool>
-          </property>
-          <property name="scrollOnExpand">
-           <bool>true</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_27">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Snapshot output dir</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QgsFileWidget" name="f_output">
-             <property name="storageMode">
-              <enum>QgsFileWidget::GetDirectory</enum>
-             </property>
-             <property name="options">
-              <set>QFileDialog::ShowDirsOnly</set>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QgsCollapsibleGroupBox" name="mGroupBox_4">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="title">
-           <string>Layers</string>
-          </property>
-          <property name="flat">
-           <bool>false</bool>
-          </property>
-          <property name="collapsed">
-           <bool>false</bool>
-          </property>
-          <property name="scrollOnExpand">
-           <bool>true</bool>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-           <item>
-            <layout class="QGridLayout" name="layer_grid" columnminimumwidth="0,150,0">
-             <item row="0" column="1">
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>Layer</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_6">
-               <property name="maximumSize">
-                <size>
-                 <width>80</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QLabel" name="label_5">
-               <property name="text">
-                <string>Primary</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="geometry">
+         <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>748</width>
+             <height>756</height>
+         </rect>
+     </property>
+     <property name="floating">
+         <bool>false</bool>
+     </property>
+     <property name="features">
+         <set>QDockWidget::AllDockWidgetFeatures</set>
+     </property>
+     <property name="windowTitle">
+         <string>Gemeindescan Exporter</string>
+     </property>
+     <widget class="QWidget" name="dockWidgetContents">
+         <layout class="QVBoxLayout" name="verticalLayout">
              <item>
-              <widget class="QPushButton" name="btn_add_layer_row">
-               <property name="toolTip">
-                <string>Add row</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
+                 <layout class="QHBoxLayout" name="horizontalLayout_2">
+                     <item>
+                         <layout class="QHBoxLayout" name="horizontalLayout_3">
+                             <item>
+                                 <spacer name="horizontalSpacer_2">
+                                     <property name="orientation">
+                                         <enum>Qt::Horizontal</enum>
+                                     </property>
+                                     <property name="sizeHint" stdset="0">
+                                         <size>
+                                             <width>40</width>
+                                             <height>20</height>
+                                         </size>
+                                     </property>
+                                 </spacer>
+                             </item>
+                         </layout>
+                     </item>
+                     <item>
+                         <widget class="QPushButton" name="btn_settings">
+                             <property name="text">
+                                 <string/>
+                             </property>
+                             <property name="flat">
+                                 <bool>true</bool>
+                             </property>
+                         </widget>
+                     </item>
+                 </layout>
              </item>
              <item>
-              <spacer name="horizontalSpacer_4">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
+                 <widget class="QScrollArea" name="scrollArea">
+                     <property name="widgetResizable">
+                         <bool>true</bool>
+                     </property>
+                     <widget class="QWidget" name="scrollAreaWidgetContents_2">
+                         <property name="geometry">
+                             <rect>
+                                 <x>0</x>
+                                 <y>0</y>
+                                 <width>728</width>
+                                 <height>509</height>
+                             </rect>
+                         </property>
+                         <layout class="QVBoxLayout" name="verticalLayout_10">
+                             <item>
+                                 <widget class="QgsCollapsibleGroupBox" name="mGroupBox_3">
+                                     <property name="enabled">
+                                         <bool>true</bool>
+                                     </property>
+                                     <property name="font">
+                                         <font>
+                                             <weight>75</weight>
+                                             <bold>true</bold>
+                                         </font>
+                                     </property>
+                                     <property name="title">
+                                         <string>Export settings</string>
+                                     </property>
+                                     <property name="flat">
+                                         <bool>false</bool>
+                                     </property>
+                                     <property name="collapsed">
+                                         <bool>false</bool>
+                                     </property>
+                                     <property name="scrollOnExpand">
+                                         <bool>true</bool>
+                                     </property>
+                                     <layout class="QGridLayout" name="gridLayout_3">
+                                         <item row="0" column="0">
+                                             <widget class="QLabel" name="label_27">
+                                                 <property name="font">
+                                                     <font>
+                                                         <weight>75</weight>
+                                                         <bold>true</bold>
+                                                     </font>
+                                                 </property>
+                                                 <property name="text">
+                                                     <string>Snapshot output dir</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="0" column="1">
+                                             <widget class="QgsFileWidget" name="f_output">
+                                                 <property name="storageMode">
+                                                     <enum>QgsFileWidget::GetDirectory</enum>
+                                                 </property>
+                                                 <property name="options">
+                                                     <set>QFileDialog::ShowDirsOnly</set>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                     </layout>
+                                 </widget>
+                             </item>
+                             <item>
+                                 <widget class="QgsCollapsibleGroupBox" name="mGroupBox_4">
+                                     <property name="enabled">
+                                         <bool>true</bool>
+                                     </property>
+                                     <property name="font">
+                                         <font>
+                                             <weight>75</weight>
+                                             <bold>true</bold>
+                                         </font>
+                                     </property>
+                                     <property name="title">
+                                         <string>Layers</string>
+                                     </property>
+                                     <property name="flat">
+                                         <bool>false</bool>
+                                     </property>
+                                     <property name="collapsed">
+                                         <bool>false</bool>
+                                     </property>
+                                     <property name="scrollOnExpand">
+                                         <bool>true</bool>
+                                     </property>
+                                     <layout class="QVBoxLayout" name="verticalLayout_2">
+                                         <item>
+                                             <layout class="QGridLayout" name="layer_grid" columnminimumwidth="0,150,0">
+                                                 <item row="0" column="1">
+                                                     <widget class="QLabel" name="label_2">
+                                                         <property name="text">
+                                                             <string>Layer</string>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item row="0" column="0">
+                                                     <widget class="QLabel" name="label_6">
+                                                         <property name="maximumSize">
+                                                             <size>
+                                                                 <width>80</width>
+                                                                 <height>16777215</height>
+                                                             </size>
+                                                         </property>
+                                                         <property name="text">
+                                                             <string/>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item row="0" column="2">
+                                                     <widget class="QLabel" name="label_5">
+                                                         <property name="text">
+                                                             <string>Primary</string>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                             </layout>
+                                         </item>
+                                         <item>
+                                             <layout class="QHBoxLayout" name="horizontalLayout_5">
+                                                 <item>
+                                                     <widget class="QPushButton" name="btn_add_layer_row">
+                                                         <property name="toolTip">
+                                                             <string>Add row</string>
+                                                         </property>
+                                                         <property name="text">
+                                                             <string/>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item>
+                                                     <spacer name="horizontalSpacer_4">
+                                                         <property name="orientation">
+                                                             <enum>Qt::Horizontal</enum>
+                                                         </property>
+                                                         <property name="sizeHint" stdset="0">
+                                                             <size>
+                                                                 <width>40</width>
+                                                                 <height>20</height>
+                                                             </size>
+                                                         </property>
+                                                     </spacer>
+                                                 </item>
+                                             </layout>
+                                         </item>
+                                     </layout>
+                                 </widget>
+                             </item>
+                             <item>
+                                 <widget class="QgsCollapsibleGroupBox" name="mGroupBox_2">
+                                     <property name="enabled">
+                                         <bool>true</bool>
+                                     </property>
+                                     <property name="font">
+                                         <font>
+                                             <weight>75</weight>
+                                             <bold>true</bold>
+                                         </font>
+                                     </property>
+                                     <property name="title">
+                                         <string>Snapshot settings</string>
+                                     </property>
+                                     <property name="flat">
+                                         <bool>false</bool>
+                                     </property>
+                                     <property name="collapsed">
+                                         <bool>false</bool>
+                                     </property>
+                                     <property name="scrollOnExpand">
+                                         <bool>true</bool>
+                                     </property>
+                                     <layout class="QGridLayout" name="gridLayout">
+                                         <item row="3" column="1">
+                                             <layout class="QGridLayout" name="source_grid" columnminimumwidth="0,150,0">
+                                                 <item row="0" column="1">
+                                                     <widget class="QLabel" name="label_3">
+                                                         <property name="text">
+                                                             <string>Url</string>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item row="0" column="0">
+                                                     <widget class="QLabel" name="label_7">
+                                                         <property name="maximumSize">
+                                                             <size>
+                                                                 <width>80</width>
+                                                                 <height>16777215</height>
+                                                             </size>
+                                                         </property>
+                                                         <property name="text">
+                                                             <string/>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item row="0" column="2">
+                                                     <widget class="QLabel" name="label_8">
+                                                         <property name="text">
+                                                             <string>Title</string>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                             </layout>
+                                         </item>
+                                         <item row="3" column="0">
+                                             <widget class="QLabel" name="label_21">
+                                                 <property name="font">
+                                                     <font>
+                                                         <weight>75</weight>
+                                                         <bold>true</bold>
+                                                     </font>
+                                                 </property>
+                                                 <property name="text">
+                                                     <string>Sources</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="6" column="0">
+                                             <widget class="QLabel" name="label_15">
+                                                 <property name="text">
+                                                     <string>Bounds</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="2" column="1">
+                                             <widget class="QTextEdit" name="input_description"/>
+                                         </item>
+                                         <item row="0" column="0">
+                                             <widget class="QLabel" name="label_20">
+                                                 <property name="font">
+                                                     <font>
+                                                         <weight>75</weight>
+                                                         <bold>true</bold>
+                                                     </font>
+                                                 </property>
+                                                 <property name="text">
+                                                     <string>Name</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="4" column="1">
+                                             <layout class="QHBoxLayout" name="horizontalLayout_6">
+                                                 <item>
+                                                     <widget class="QPushButton" name="btn_add_source_row">
+                                                         <property name="toolTip">
+                                                             <string>Add row</string>
+                                                         </property>
+                                                         <property name="text">
+                                                             <string/>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item>
+                                                     <spacer name="horizontalSpacer_5">
+                                                         <property name="orientation">
+                                                             <enum>Qt::Horizontal</enum>
+                                                         </property>
+                                                         <property name="sizeHint" stdset="0">
+                                                             <size>
+                                                                 <width>40</width>
+                                                                 <height>20</height>
+                                                             </size>
+                                                         </property>
+                                                     </spacer>
+                                                 </item>
+                                             </layout>
+                                         </item>
+                                         <item row="6" column="1">
+                                             <layout class="QGridLayout" name="gridLayout_2">
+                                                 <item row="1" column="1" colspan="2">
+                                                     <widget class="QPushButton" name="btn_calculate_extent">
+                                                         <property name="text">
+                                                             <string>Calculate bounds</string>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item row="0" column="2">
+                                                     <widget class="QSpinBox" name="sb_extent_precision"/>
+                                                 </item>
+                                                 <item row="0" column="0">
+                                                     <widget class="QLineEdit" name="le_extent"/>
+                                                 </item>
+                                                 <item row="0" column="1">
+                                                     <widget class="QLabel" name="label">
+                                                         <property name="text">
+                                                             <string>Precision</string>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                             </layout>
+                                         </item>
+                                         <item row="1" column="0">
+                                             <widget class="QLabel" name="label_16">
+                                                 <property name="text">
+                                                     <string>Title</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="5" column="1">
+                                             <widget class="Line" name="line">
+                                                 <property name="orientation">
+                                                     <enum>Qt::Horizontal</enum>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="2" column="0">
+                                             <widget class="QLabel" name="label_14">
+                                                 <property name="text">
+                                                     <string>Description</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="0" column="1">
+                                             <widget class="QLineEdit" name="input_name"/>
+                                         </item>
+                                         <item row="1" column="1">
+                                             <widget class="QLineEdit" name="input_title"/>
+                                         </item>
+                                     </layout>
+                                 </widget>
+                             </item>
+                         </layout>
+                     </widget>
+                 </widget>
              </item>
-            </layout>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QgsCollapsibleGroupBox" name="mGroupBox_2">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="title">
-           <string>Snapshot settings</string>
-          </property>
-          <property name="flat">
-           <bool>false</bool>
-          </property>
-          <property name="collapsed">
-           <bool>false</bool>
-          </property>
-          <property name="scrollOnExpand">
-           <bool>true</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout">
-           <item row="3" column="1">
-            <layout class="QGridLayout" name="source_grid" columnminimumwidth="0,150,0">
-             <item row="0" column="1">
-              <widget class="QLabel" name="label_3">
-               <property name="text">
-                <string>Url</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_7">
-               <property name="maximumSize">
-                <size>
-                 <width>80</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QLabel" name="label_8">
-               <property name="text">
-                <string>Title</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_21">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Sources</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="label_15">
-             <property name="text">
-              <string>Bounds</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QTextEdit" name="input_description"/>
-           </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_20">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Name</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_6">
-             <item>
-              <widget class="QPushButton" name="btn_add_source_row">
-               <property name="toolTip">
-                <string>Add row</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_5">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
-           <item row="6" column="1">
-            <layout class="QGridLayout" name="gridLayout_2">
-             <item row="1" column="1" colspan="2">
-              <widget class="QPushButton" name="btn_calculate_extent">
-               <property name="text">
-                <string>Calculate bounds</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QSpinBox" name="sb_extent_precision"/>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLineEdit" name="le_extent"/>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="label">
-               <property name="text">
-                <string>Precision</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_16">
-             <property name="text">
-              <string>Title</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="Line" name="line">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_14">
-             <property name="text">
-              <string>Description</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="input_name"/>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLineEdit" name="input_title"/>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </widget>
-    </item>
     <item>
      <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
       <property name="font">

--- a/SpatialDataPackageExport/resources/ui/settings_dialog.ui
+++ b/SpatialDataPackageExport/resources/ui/settings_dialog.ui
@@ -28,7 +28,7 @@
                                 <x>0</x>
                                 <y>0</y>
                                 <width>477</width>
-                                <height>250</height>
+                                <height>219</height>
                             </rect>
                         </property>
                         <layout class="QVBoxLayout" name="verticalLayout">
@@ -79,8 +79,32 @@
                     </widget>
                 </widget>
             </item>
+            <item>
+                <widget class="QDialogButtonBox" name="buttonBox">
+                    <property name="standardButtons">
+                        <set>QDialogButtonBox::Ok</set>
+                    </property>
+                </widget>
+            </item>
         </layout>
     </widget>
     <resources/>
-    <connections/>
+    <connections>
+        <connection>
+            <sender>buttonBox</sender>
+            <signal>accepted()</signal>
+            <receiver>extent_chooser</receiver>
+            <slot>accept()</slot>
+            <hints>
+                <hint type="sourcelabel">
+                    <x>248</x>
+                    <y>254</y>
+                </hint>
+                <hint type="destinationlabel">
+                    <x>157</x>
+                    <y>274</y>
+                </hint>
+            </hints>
+        </connection>
+    </connections>
 </ui>

--- a/SpatialDataPackageExport/resources/ui/settings_dialog.ui
+++ b/SpatialDataPackageExport/resources/ui/settings_dialog.ui
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+    <class>extent_chooser</class>
+    <widget class="QDialog" name="extent_chooser">
+        <property name="windowModality">
+            <enum>Qt::WindowModal</enum>
+        </property>
+        <property name="geometry">
+            <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>497</width>
+                <height>270</height>
+            </rect>
+        </property>
+        <property name="windowTitle">
+            <string>Dialog</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+                <widget class="QScrollArea" name="scrollArea">
+                    <property name="widgetResizable">
+                        <bool>true</bool>
+                    </property>
+                    <widget class="QWidget" name="scrollAreaWidgetContents">
+                        <property name="geometry">
+                            <rect>
+                                <x>0</x>
+                                <y>0</y>
+                                <width>477</width>
+                                <height>250</height>
+                            </rect>
+                        </property>
+                        <layout class="QVBoxLayout" name="verticalLayout">
+                            <item>
+                                <widget class="QGroupBox" name="groupBox">
+                                    <property name="title">
+                                        <string>Add snapshot layer to the map</string>
+                                    </property>
+                                    <layout class="QHBoxLayout" name="horizontalLayout">
+                                        <item>
+                                            <widget class="QRadioButton" name="rb_layer_memory">
+                                                <property name="text">
+                                                    <string>As memory layer</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <widget class="QRadioButton" name="rb_layer_geojson">
+                                                <property name="text">
+                                                    <string>As GeoJSON layer</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                        <item>
+                                            <widget class="QRadioButton" name="rb_layer_none">
+                                                <property name="text">
+                                                    <string>Do not add</string>
+                                                </property>
+                                            </widget>
+                                        </item>
+                                    </layout>
+                                </widget>
+                            </item>
+                            <item>
+                                <spacer name="verticalSpacer">
+                                    <property name="orientation">
+                                        <enum>Qt::Vertical</enum>
+                                    </property>
+                                    <property name="sizeHint" stdset="0">
+                                        <size>
+                                            <width>20</width>
+                                            <height>40</height>
+                                        </size>
+                                    </property>
+                                </spacer>
+                            </item>
+                        </layout>
+                    </widget>
+                </widget>
+            </item>
+        </layout>
+    </widget>
+    <resources/>
+    <connections/>
+</ui>

--- a/SpatialDataPackageExport/test/test_datapackage.py
+++ b/SpatialDataPackageExport/test/test_datapackage.py
@@ -17,6 +17,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SpatialDataPackageExport.  If not, see <https://www.gnu.org/licenses/>.
 import json
+from pathlib import Path
 
 from qgis.core import QgsProcessingFeedback, QgsVectorLayer, QgsVectorDataProvider
 
@@ -76,6 +77,14 @@ def test_points_with_radius(new_project, points_with_radius, layer_empty_points)
     snapshot = writer.create_snapshot(name, snapshot_config, [styled_layer])
     expected_snapshot_dict = get_test_json('snapshots', 'points_with_radius.json')
     assert snapshot.to_dict() == expected_snapshot_dict
+
+
+def test_styled_layer(tmp_path, points_with_radius):
+    styled_layer: StyledLayer = StyledLayer('point-sample-snapshot', points_with_radius.id(),
+                                            [],
+                                            StyleType.PointStyle)
+    styled_layer.save_as_geojson(tmp_path)
+    assert Path(tmp_path, 'point-sample-snapshot.geojson').exists()
 
 
 def update_fields(converter: StylesToAttributes, layer: QgsVectorLayer):

--- a/SpatialDataPackageExport/ui/dock_widget.py
+++ b/SpatialDataPackageExport/ui/dock_widget.py
@@ -57,6 +57,10 @@ class ExporterDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
     def __init__(self, iface: QgisInterface, parent=None):
         super(ExporterDockWidget, self).__init__(parent)
         self.setupUi(self)
+
+        # noinspection PyCallByClass
+        self.btn_settings.setIcon(QgsApplication.getThemeIcon('/propertyicons/settings.svg'))
+
         self.iface = iface
         # Template can be configured via settings
         self.config = load_config_from_template()

--- a/SpatialDataPackageExport/ui/dock_widget.py
+++ b/SpatialDataPackageExport/ui/dock_widget.py
@@ -33,6 +33,7 @@ from qgis.core import (QgsProcessingContext, QgsVectorLayer, QgsProject,
 from qgis.gui import QgsMapLayerComboBox, QgisInterface
 
 from .extent_dialog import ExtentChooserDialog
+from .settings_dialog import SettingsDialog
 from ..core.datapackage import DatapackageWriter
 from ..core.processing.task_runner import TaskWrapper, create_styles_to_attributes_tasks
 from ..core.utils import load_config_from_template, extent_to_datapackage_bounds, load_snapshot_template
@@ -276,6 +277,11 @@ class ExporterDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         if result:
             self.extent = extent_chooser.get_extent(self.sb_extent_precision.value())
             self.le_extent.setText(self.extent.toString(self.sb_extent_precision.value()))
+
+    @pyqtSlot()
+    def on_btn_settings_clicked(self):
+        settings_dialog = SettingsDialog()
+        settings_dialog.exec()
 
     def _disable_ui(self):
         for item in self.responsive_items:

--- a/SpatialDataPackageExport/ui/dock_widget.py
+++ b/SpatialDataPackageExport/ui/dock_widget.py
@@ -38,7 +38,7 @@ from .settings_dialog import SettingsDialog
 from ..core.datapackage import DatapackageWriter
 from ..core.processing.task_runner import TaskWrapper, create_styles_to_attributes_tasks
 from ..core.utils import load_config_from_template, extent_to_datapackage_bounds, load_snapshot_template
-from ..definitions.configurable_settings import Settings
+from ..definitions.configurable_settings import Settings, LayerFormatOptions
 from ..model.config import SnapshotConfig
 from ..model.snapshot import Legend, Source
 from ..model.styled_layer import StyledLayer
@@ -174,7 +174,7 @@ class ExporterDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         with open(output_file, 'w') as f:
             json.dump(snapshot.to_dict(), f)
 
-        if Settings.layer_format.get() == 'none':
+        if Settings.layer_format.get() == LayerFormatOptions.none.value:
             LOGGER.debug('Removing memory layers')
             for row in self.layer_rows.values():
                 QgsProject.instance().removeMapLayer(row['styled_layer'].layer_id)
@@ -195,7 +195,7 @@ class ExporterDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 QgsProject.instance().addMapLayer(output_layer)
                 styled_layer = StyledLayer(row['layer_name'], output_layer.id(), legends, style_type)
 
-                if Settings.layer_format.get() == 'geojson':
+                if Settings.layer_format.get() == LayerFormatOptions.geojson.value:
                     geojson_path = styled_layer.save_as_geojson(Path(self.f_output.filePath()))
                     output_layer = QgsVectorLayer(str(geojson_path), output_layer.name())
                     QgsProject.instance().removeMapLayer(styled_layer.layer_id)

--- a/SpatialDataPackageExport/ui/settings_dialog.py
+++ b/SpatialDataPackageExport/ui/settings_dialog.py
@@ -1,0 +1,74 @@
+#  Gispo Ltd., hereby disclaims all copyright interest in the program SpatialDataPackageExport
+#  Copyright (C) 2020 Gispo Ltd (https://www.gispo.fi/).
+#
+#
+#  This file is part of SpatialDataPackageExport.
+#
+#  SpatialDataPackageExport is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SpatialDataPackageExport is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SpatialDataPackageExport.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+from typing import Optional
+
+from PyQt5.QtWidgets import QDialog, QRadioButton
+
+from ..definitions.configurable_settings import Settings
+from ..qgis_plugin_tools.tools.custom_logging import bar_msg
+from ..qgis_plugin_tools.tools.decorations import log_if_fails
+from ..qgis_plugin_tools.tools.i18n import tr
+from ..qgis_plugin_tools.tools.resources import load_ui, plugin_name
+
+FORM_CLASS = load_ui('settings_dialog.ui')
+LOGGER = logging.getLogger(plugin_name())
+
+
+class SettingsDialog(QDialog, FORM_CLASS):
+
+    def __init__(self, parent=None):
+        QDialog.__init__(self, parent)
+        self.setupUi(self)
+
+        self.__set_initial_values()
+        self.__initialize_ui()
+
+    @log_if_fails
+    def __initialize_ui(self):
+        # Snapshot layer format
+        def set_layer_format_setting(is_checked: bool, layer_format: str):
+            if is_checked:
+                LOGGER.debug(f'Setting layer_format to {layer_format}')
+                Settings.layer_format.set(layer_format)
+
+        self.rb_layer_memory.toggled.connect(
+            lambda: set_layer_format_setting(self.rb_layer_memory.isChecked(), 'memory'))
+        self.rb_layer_geojson.toggled.connect(
+            lambda: set_layer_format_setting(self.rb_layer_geojson.isChecked(), 'geojson'))
+        self.rb_layer_none.toggled.connect(lambda: set_layer_format_setting(self.rb_layer_none.isChecked(), 'none'))
+
+    @log_if_fails
+    def __set_initial_values(self):
+        LOGGER.debug('Initializing settings')
+
+        # Snapshot layer format
+        snapshot_layer_format = Settings.layer_format.get()
+        rb_button: QRadioButton = self.__get_widget(f'rb_layer_{snapshot_layer_format}')
+        if rb_button:
+            rb_button.setChecked(True)
+
+    def __get_widget(self, widget_name: str) -> Optional:
+        try:
+            LOGGER.debug(widget_name)
+            return getattr(self, widget_name)
+        except AttributeError:
+            LOGGER.warning(tr('Invalid widget for setting', extra=bar_msg(widget_name)))
+            return None


### PR DESCRIPTION
This PR add settings dialog and one setting there to decide whether to add snapshot layers to the map as memory layer, as geojson layer or not at all.

![image](https://user-images.githubusercontent.com/33314057/100195902-b4843200-2f00-11eb-9370-3aa6bb38a2e7.png)

This PR resolves #12.