### PR TITLE
Data licenses

### DIFF
--- a/SpatialDataPackageExport/core/datapackage.py
+++ b/SpatialDataPackageExport/core/datapackage.py
@@ -116,7 +116,7 @@ class DataPackageHandler:
         snapshot.sources = snapshot_config.sources
         snapshot.gemeindescan_meta = snapshot_config.gemeindescan_meta
         if snapshot_license:
-            snapshot.licenses = snapshot_license
+            snapshot.licenses = [snapshot_license]
 
         LOGGER.debug('Updating resources')
         initial_resources = snapshot.resources

--- a/SpatialDataPackageExport/definitions/configurable_settings.py
+++ b/SpatialDataPackageExport/definitions/configurable_settings.py
@@ -40,6 +40,14 @@ class Settings(enum.Enum):
     snapshot_template = resources_path('templates', 'snapshot-template.json')
     layer_format = 'memory'
     crop_layers = True
+    licences = {
+        'Creative Commons CC Zero': 'https://creativecommons.org/share-your-work/public-domain/cc0/',
+        'Open Data Commons Public Domain Dedication and Licence': 'https://opendatacommons.org/licenses/pddl/',
+        'Creative Commons Attribution 4.0': 'https://creativecommons.org/licenses/by/4.0/',
+        'Open Data Commons Attribution License': 'https://opendatacommons.org/licenses/by/1-0/',
+        'Creative Commons Attribution Share-Alike 4.0': 'https://creativecommons.org/licenses/by-sa/4.0/',
+        'Open Data Commons Open Database License': 'https://opendatacommons.org/licenses/odbl/',
+    }
 
     _options = {'layer_format': [option.value for option in LayerFormatOptions]}
 
@@ -50,6 +58,8 @@ class Settings(enum.Enum):
             typehint = bool
         elif self == Settings.extent_precision:
             typehint = int
+        elif self == Settings.licences:
+            return json.loads(get_setting(self.name, json.dumps(self.value), str))
         return get_setting(self.name, self.value, typehint)
 
     def set(self, value: Union[str, int, float, bool]) -> bool:
@@ -57,6 +67,8 @@ class Settings(enum.Enum):
         options = self.get_options()
         if options and value not in options:
             raise QgsPluginException(tr('Invalid option. Choose something from values {}', options))
+        if self == Settings.licences:
+            value = json.dumps(value)
         return set_setting(self.name, value)
 
     def get_options(self) -> List[any]:

--- a/SpatialDataPackageExport/definitions/configurable_settings.py
+++ b/SpatialDataPackageExport/definitions/configurable_settings.py
@@ -41,12 +41,18 @@ class Settings(enum.Enum):
     layer_format = 'memory'
     crop_layers = True
     licences = {
-        'Creative Commons CC Zero': 'https://creativecommons.org/share-your-work/public-domain/cc0/',
-        'Open Data Commons Public Domain Dedication and Licence': 'https://opendatacommons.org/licenses/pddl/',
-        'Creative Commons Attribution 4.0': 'https://creativecommons.org/licenses/by/4.0/',
-        'Open Data Commons Attribution License': 'https://opendatacommons.org/licenses/by/1-0/',
-        'Creative Commons Attribution Share-Alike 4.0': 'https://creativecommons.org/licenses/by-sa/4.0/',
-        'Open Data Commons Open Database License': 'https://opendatacommons.org/licenses/odbl/',
+        'Creative Commons CC Zero': {'type': 'CC0-1.0',
+                                     'url': 'https://creativecommons.org/publicdomain/zero/1.0/'},
+        'Open Data Commons Public Domain Dedication and Licence': {'type': 'PDDL-1.0',
+                                                                   'url': 'https://opendatacommons.org/licenses/pddl/'},
+        'Creative Commons Attribution 4.0': {'type': 'CC-BY-4.0',
+                                             'url': 'https://creativecommons.org/licenses/by/4.0/'},
+        'Open Data Commons Attribution License': {'type': 'ODC-BY-1.0',
+                                                  'url': 'https://opendefinition.org/licenses/odc-by'},
+        'Creative Commons Attribution Share-Alike 4.0': {'type': 'CC-BY-SA-4.0',
+                                                         'url': 'https://creativecommons.org/licenses/by-sa/4.0/'},
+        'Open Data Commons Open Database License': {'type': 'ODbL-1.0',
+                                                    'url': 'https://opendatacommons.org/licenses/odbl/'},
     }
 
     _options = {'layer_format': [option.value for option in LayerFormatOptions]}

--- a/SpatialDataPackageExport/model/snapshot.py
+++ b/SpatialDataPackageExport/model/snapshot.py
@@ -258,7 +258,7 @@ class View:
 class Snapshot:
 
     def __init__(self, name: str, title: str, description: str, version: str, datapackage_version: str,
-                 gemeindescan_version: str, gemeindescan_meta: GemeindescanMeta, format: str, license: str,
+                 gemeindescan_version: str, gemeindescan_meta: GemeindescanMeta, format: str,
                  licenses: List[License], keywords: List[str], views: List[View], sources: List[Source],
                  resources: List[Resource], maintainers: List[Maintainer], contributors: List[Contributor]) -> None:
         self.name = name
@@ -269,7 +269,6 @@ class Snapshot:
         self.gemeindescan_version = gemeindescan_version
         self.gemeindescan_meta = gemeindescan_meta
         self.format = format
-        self.license = license
         self.licenses = licenses
         self.keywords = keywords
         self.views = views
@@ -289,7 +288,6 @@ class Snapshot:
         gemeindescan_version = from_str(obj.get("gemeindescan_version"))
         gemeindescan_meta = GemeindescanMeta.from_dict(obj.get("gemeindescan_meta"))
         format = from_str(obj.get("format"))
-        license = from_str(obj.get("license"))
         licenses = from_list(License.from_dict, obj.get("licenses"))
         keywords = from_list(from_str, obj.get("keywords"))
         views = from_list(View.from_dict, obj.get("views", []))
@@ -310,7 +308,6 @@ class Snapshot:
         result["gemeindescan_version"] = from_str(self.gemeindescan_version)
         result["gemeindescan_meta"] = to_class(GemeindescanMeta, self.gemeindescan_meta)
         result["format"] = from_str(self.format)
-        result["license"] = from_str(self.license)
         result["licenses"] = from_list(lambda x: to_class(License, x), self.licenses)
         result["keywords"] = from_list(from_str, self.keywords)
         result["views"] = from_list(lambda x: to_class(View, x), self.views)

--- a/SpatialDataPackageExport/model/snapshot.py
+++ b/SpatialDataPackageExport/model/snapshot.py
@@ -266,7 +266,7 @@ class Snapshot:
 
     def __init__(self, name: str, title: str, description: str, version: str, datapackage_version: str,
                  gemeindescan_version: str, gemeindescan_meta: GemeindescanMeta, format: str,
-                 licenses: License, keywords: List[str], views: List[View], sources: List[Source],
+                 licenses: List[License], keywords: List[str], views: List[View], sources: List[Source],
                  resources: List[Resource], maintainers: List[Maintainer], contributors: List[Contributor]) -> None:
         self.name = name
         self.title = title
@@ -295,7 +295,7 @@ class Snapshot:
         gemeindescan_version = from_str(obj.get("gemeindescan_version"))
         gemeindescan_meta = GemeindescanMeta.from_dict(obj.get("gemeindescan_meta"))
         format = from_str(obj.get("format"))
-        licenses = License.from_dict(obj.get("licenses"))
+        licenses = from_list(License.from_dict, obj.get("licenses"))
         keywords = from_list(from_str, obj.get("keywords"))
         views = from_list(View.from_dict, obj.get("views", []))
         sources = from_list(Source.from_dict, obj.get("sources"))
@@ -315,7 +315,7 @@ class Snapshot:
         result["gemeindescan_version"] = from_str(self.gemeindescan_version)
         result["gemeindescan_meta"] = to_class(GemeindescanMeta, self.gemeindescan_meta)
         result["format"] = from_str(self.format)
-        result["licenses"] = to_class(License, self.licenses)
+        result["licenses"] = from_list(lambda x: to_class(License, x), self.licenses)
         result["keywords"] = from_list(from_str, self.keywords)
         result["views"] = from_list(lambda x: to_class(View, x), self.views)
         result["sources"] = from_list(lambda x: to_class(Source, x), self.sources)

--- a/SpatialDataPackageExport/model/snapshot.py
+++ b/SpatialDataPackageExport/model/snapshot.py
@@ -71,21 +71,24 @@ class GemeindescanMeta:
 
 class License:
 
-    def __init__(self, url: str, type: str) -> None:
+    def __init__(self, url: str, type: str, title: str) -> None:
         self.url = url
         self.type = type
+        self.title = title
 
     @staticmethod
     def from_dict(obj: Any) -> 'License':
         assert isinstance(obj, dict)
         url = from_str(obj.get("url"))
         type = from_str(obj.get("type"))
-        return License(url, type)
+        title = from_str(obj.get("title"))
+        return License(url, type, title)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["url"] = from_str(self.url)
         result["type"] = from_str(self.type)
+        result["title"] = from_str(self.title)
         return result
 
 
@@ -111,9 +114,11 @@ class Maintainer:
 
 class Resource:
 
-    def __init__(self, name: str, mediatype: str, data: Optional[Dict] = None, path: Optional[str] = None) -> None:
+    def __init__(self, name: str, mediatype: str, licenses: List[License], data: Optional[Dict] = None,
+                 path: Optional[str] = None) -> None:
         self.name = name
         self.mediatype = mediatype
+        self.licenses = licenses
         self.data = data
         self.path = path
 
@@ -122,14 +127,16 @@ class Resource:
         assert isinstance(obj, dict)
         name = from_str(obj.get("name"))
         mediatype = from_str(obj.get("mediatype"))
+        licenses = from_list(License.from_dict, obj.get("licenses", []))
         data = from_union([from_dict, from_none], obj.get("data"))
         path = from_union([from_str, from_none], obj.get("path"))
-        return Resource(name, mediatype, data, path)
+        return Resource(name, mediatype, licenses, data, path)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["name"] = from_str(self.name)
         result["mediatype"] = from_str(self.mediatype)
+        result["licenses"] = from_list(lambda x: to_class(License, x), self.licenses)
         if self.data is not None:
             result["data"] = self.data
         if self.path is not None:
@@ -259,7 +266,7 @@ class Snapshot:
 
     def __init__(self, name: str, title: str, description: str, version: str, datapackage_version: str,
                  gemeindescan_version: str, gemeindescan_meta: GemeindescanMeta, format: str,
-                 licenses: List[License], keywords: List[str], views: List[View], sources: List[Source],
+                 licenses: License, keywords: List[str], views: List[View], sources: List[Source],
                  resources: List[Resource], maintainers: List[Maintainer], contributors: List[Contributor]) -> None:
         self.name = name
         self.title = title
@@ -288,7 +295,7 @@ class Snapshot:
         gemeindescan_version = from_str(obj.get("gemeindescan_version"))
         gemeindescan_meta = GemeindescanMeta.from_dict(obj.get("gemeindescan_meta"))
         format = from_str(obj.get("format"))
-        licenses = from_list(License.from_dict, obj.get("licenses"))
+        licenses = License.from_dict(obj.get("licenses"))
         keywords = from_list(from_str, obj.get("keywords"))
         views = from_list(View.from_dict, obj.get("views", []))
         sources = from_list(Source.from_dict, obj.get("sources"))
@@ -296,7 +303,7 @@ class Snapshot:
         maintainers = from_list(Maintainer.from_dict, obj.get("maintainers"))
         contributors = from_list(Contributor.from_dict, obj.get("contributors"))
         return Snapshot(name, title, description, version, datapackage_version, gemeindescan_version, gemeindescan_meta,
-                        format, license, licenses, keywords, views, sources, resources, maintainers, contributors)
+                        format, licenses, keywords, views, sources, resources, maintainers, contributors)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -308,7 +315,7 @@ class Snapshot:
         result["gemeindescan_version"] = from_str(self.gemeindescan_version)
         result["gemeindescan_meta"] = to_class(GemeindescanMeta, self.gemeindescan_meta)
         result["format"] = from_str(self.format)
-        result["licenses"] = from_list(lambda x: to_class(License, x), self.licenses)
+        result["licenses"] = to_class(License, self.licenses)
         result["keywords"] = from_list(from_str, self.keywords)
         result["views"] = from_list(lambda x: to_class(View, x), self.views)
         result["sources"] = from_list(lambda x: to_class(Source, x), self.sources)

--- a/SpatialDataPackageExport/model/styled_layer.py
+++ b/SpatialDataPackageExport/model/styled_layer.py
@@ -48,7 +48,9 @@ class StyledLayer:
     def get_licenses(self) -> List[License]:
         licenses = self.layer.metadata().licenses()
         available_licenses = Settings.licences.get()
-        return [License(available_licenses.get(license_, ''), license_) for license_ in licenses]
+        return [License(available_licenses.get(license_, {}).get('url', ''),
+                        available_licenses.get(license_, {}).get('type', ''), license_)
+                for license_ in licenses]
 
     def get_geojson_data(self) -> Dict:
         source = self.layer.source()

--- a/SpatialDataPackageExport/model/styled_layer.py
+++ b/SpatialDataPackageExport/model/styled_layer.py
@@ -23,7 +23,8 @@ from typing import List, Dict, Union
 
 from qgis.core import QgsVectorFileWriter, QgsCoordinateReferenceSystem, QgsProject, QgsVectorLayer
 
-from .snapshot import Legend
+from .snapshot import Legend, License
+from ..definitions.configurable_settings import Settings
 from ..definitions.types import StyleType
 from ..qgis_plugin_tools.tools.resources import resources_path
 
@@ -43,6 +44,11 @@ class StyledLayer:
     def get_keywords(self) -> List[str]:
         keyword_lists = self.layer.metadata().keywords().values()
         return [keyword for keyword_list in keyword_lists for keyword in keyword_list]
+
+    def get_licenses(self) -> List[License]:
+        licenses = self.layer.metadata().licenses()
+        available_licenses = Settings.licences.get()
+        return [License(available_licenses.get(license_, ''), license_) for license_ in licenses]
 
     def get_geojson_data(self) -> Dict:
         source = self.layer.source()

--- a/SpatialDataPackageExport/resources/templates/snapshot-template.json
+++ b/SpatialDataPackageExport/resources/templates/snapshot-template.json
@@ -13,11 +13,11 @@
       "bfs_number": 1051
     },
     "format": "geojson",
-    "license": "ODC-By-1.0",
+    "license": "Open Data Commons Attribution License",
     "licenses": [
       {
         "url": "https://opendatacommons.org/licenses/by/1.0/",
-        "type": "ODC-By-1.0"
+        "type": "Open Data Commons Attribution License"
       }
     ],
     "keywords": [

--- a/SpatialDataPackageExport/resources/templates/snapshot-template.json
+++ b/SpatialDataPackageExport/resources/templates/snapshot-template.json
@@ -13,13 +13,11 @@
       "bfs_number": 1051
     },
     "format": "geojson",
-    "license": "Open Data Commons Attribution License",
-    "licenses": [
-      {
-        "url": "https://opendatacommons.org/licenses/by/1.0/",
-        "type": "Open Data Commons Attribution License"
-      }
-    ],
+    "licenses": {
+      "url": "https://opendatacommons.org/licenses/by/1.0/",
+      "type": "ODC-By-1.0",
+      "title": "Open Data Commons Attribution License"
+    },
     "keywords": [
       "europe",
       "switzerland",

--- a/SpatialDataPackageExport/resources/templates/snapshot-template.json
+++ b/SpatialDataPackageExport/resources/templates/snapshot-template.json
@@ -13,11 +13,13 @@
       "bfs_number": 1051
     },
     "format": "geojson",
-    "licenses": {
-      "url": "https://opendatacommons.org/licenses/by/1.0/",
-      "type": "ODC-By-1.0",
-      "title": "Open Data Commons Attribution License"
-    },
+    "licenses": [
+      {
+        "url": "https://opendatacommons.org/licenses/by/1.0/",
+        "type": "ODC-By-1.0",
+        "title": "Open Data Commons Attribution License"
+      }
+    ],
     "keywords": [
       "europe",
       "switzerland",

--- a/SpatialDataPackageExport/resources/ui/main_dialog_dock.ui
+++ b/SpatialDataPackageExport/resources/ui/main_dialog_dock.ui
@@ -6,8 +6,8 @@
          <rect>
              <x>0</x>
              <y>0</y>
-             <width>478</width>
-             <height>788</height>
+             <width>516</width>
+             <height>703</height>
          </rect>
      </property>
      <property name="floating">
@@ -102,9 +102,9 @@
                          <property name="geometry">
                              <rect>
                                  <x>0</x>
-                                 <y>-47</y>
-                                 <width>464</width>
-                                 <height>619</height>
+                                 <y>-230</y>
+                                 <width>482</width>
+                                 <height>652</height>
                              </rect>
                          </property>
                          <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -294,7 +294,7 @@
                                          <bool>true</bool>
                                      </property>
                                      <layout class="QGridLayout" name="gridLayout">
-                                         <item row="8" column="1">
+                                         <item row="9" column="1">
                                              <layout class="QGridLayout" name="gridLayout_2">
                                                  <item row="1" column="1">
                                                      <widget class="QLabel" name="label">
@@ -325,7 +325,41 @@
                                                  </item>
                                              </layout>
                                          </item>
-                                         <item row="3" column="0">
+                                         <item row="1" column="0">
+                                             <widget class="QLabel" name="label_16">
+                                                 <property name="text">
+                                                     <string>Title</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="5" column="1">
+                                             <layout class="QHBoxLayout" name="horizontalLayout_6">
+                                                 <item>
+                                                     <widget class="QPushButton" name="btn_add_source_row">
+                                                         <property name="toolTip">
+                                                             <string>Add row</string>
+                                                         </property>
+                                                         <property name="text">
+                                                             <string/>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item>
+                                                     <spacer name="horizontalSpacer_5">
+                                                         <property name="orientation">
+                                                             <enum>Qt::Horizontal</enum>
+                                                         </property>
+                                                         <property name="sizeHint" stdset="0">
+                                                             <size>
+                                                                 <width>40</width>
+                                                                 <height>20</height>
+                                                             </size>
+                                                         </property>
+                                                     </spacer>
+                                                 </item>
+                                             </layout>
+                                         </item>
+                                         <item row="4" column="0">
                                              <widget class="QLabel" name="label_21">
                                                  <property name="font">
                                                      <font>
@@ -338,8 +372,39 @@
                                                  </property>
                                              </widget>
                                          </item>
-                                         <item row="2" column="1">
-                                             <widget class="QTextEdit" name="input_description"/>
+                                         <item row="2" column="0">
+                                             <widget class="QLabel" name="label_14">
+                                                 <property name="text">
+                                                     <string>Description</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="9" column="0">
+                                             <widget class="QLabel" name="label_15">
+                                                 <property name="text">
+                                                     <string>Bounds</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="7" column="1">
+                                             <widget class="Line" name="line">
+                                                 <property name="orientation">
+                                                     <enum>Qt::Horizontal</enum>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="8" column="0">
+                                             <widget class="QLabel" name="label_17">
+                                                 <property name="font">
+                                                     <font>
+                                                         <weight>75</weight>
+                                                         <bold>true</bold>
+                                                     </font>
+                                                 </property>
+                                                 <property name="text">
+                                                     <string>License</string>
+                                                 </property>
+                                             </widget>
                                          </item>
                                          <item row="0" column="0">
                                              <widget class="QLabel" name="label_20">
@@ -357,7 +422,13 @@
                                          <item row="1" column="1">
                                              <widget class="QLineEdit" name="input_title"/>
                                          </item>
-                                         <item row="3" column="1">
+                                         <item row="0" column="1">
+                                             <widget class="QLineEdit" name="input_name"/>
+                                         </item>
+                                         <item row="2" column="1">
+                                             <widget class="QTextEdit" name="input_description"/>
+                                         </item>
+                                         <item row="4" column="1">
                                              <layout class="QGridLayout" name="source_grid"
                                                      columnminimumwidth="0,150,0">
                                                  <item row="0" column="1">
@@ -389,78 +460,7 @@
                                                  </item>
                                              </layout>
                                          </item>
-                                         <item row="6" column="1">
-                                             <widget class="Line" name="line">
-                                                 <property name="orientation">
-                                                     <enum>Qt::Horizontal</enum>
-                                                 </property>
-                                             </widget>
-                                         </item>
-                                         <item row="2" column="0">
-                                             <widget class="QLabel" name="label_14">
-                                                 <property name="text">
-                                                     <string>Description</string>
-                                                 </property>
-                                             </widget>
-                                         </item>
-                                         <item row="4" column="1">
-                                             <layout class="QHBoxLayout" name="horizontalLayout_6">
-                                                 <item>
-                                                     <widget class="QPushButton" name="btn_add_source_row">
-                                                         <property name="toolTip">
-                                                             <string>Add row</string>
-                                                         </property>
-                                                         <property name="text">
-                                                             <string/>
-                                                         </property>
-                                                     </widget>
-                                                 </item>
-                                                 <item>
-                                                     <spacer name="horizontalSpacer_5">
-                                                         <property name="orientation">
-                                                             <enum>Qt::Horizontal</enum>
-                                                         </property>
-                                                         <property name="sizeHint" stdset="0">
-                                                             <size>
-                                                                 <width>40</width>
-                                                                 <height>20</height>
-                                                             </size>
-                                                         </property>
-                                                     </spacer>
-                                                 </item>
-                                             </layout>
-                                         </item>
-                                         <item row="1" column="0">
-                                             <widget class="QLabel" name="label_16">
-                                                 <property name="text">
-                                                     <string>Title</string>
-                                                 </property>
-                                             </widget>
-                                         </item>
-                                         <item row="0" column="1">
-                                             <widget class="QLineEdit" name="input_name"/>
-                                         </item>
-                                         <item row="8" column="0">
-                                             <widget class="QLabel" name="label_15">
-                                                 <property name="text">
-                                                     <string>Bounds</string>
-                                                 </property>
-                                             </widget>
-                                         </item>
-                                         <item row="7" column="0">
-                                             <widget class="QLabel" name="label_17">
-                                                 <property name="font">
-                                                     <font>
-                                                         <weight>75</weight>
-                                                         <bold>true</bold>
-                                                     </font>
-                                                 </property>
-                                                 <property name="text">
-                                                     <string>License</string>
-                                                 </property>
-                                             </widget>
-                                         </item>
-                                         <item row="7" column="1">
+                                         <item row="8" column="1">
                                              <layout class="QHBoxLayout" name="horizontalLayout_4">
                                                  <item>
                                                      <spacer name="horizontalSpacer_3">
@@ -498,6 +498,26 @@
                                                      </widget>
                                                  </item>
                                              </layout>
+                                         </item>
+                                         <item row="3" column="0">
+                                             <widget class="QLabel" name="label_18">
+                                                 <property name="font">
+                                                     <font>
+                                                         <weight>75</weight>
+                                                         <bold>true</bold>
+                                                     </font>
+                                                 </property>
+                                                 <property name="text">
+                                                     <string>Keywords</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="3" column="1">
+                                             <widget class="QTextEdit" name="input_keywords">
+                                                 <property name="placeholderText">
+                                                     <string>Add one keyword per row</string>
+                                                 </property>
+                                             </widget>
                                          </item>
                                      </layout>
                                  </widget>

--- a/SpatialDataPackageExport/resources/ui/main_dialog_dock.ui
+++ b/SpatialDataPackageExport/resources/ui/main_dialog_dock.ui
@@ -6,12 +6,9 @@
          <rect>
              <x>0</x>
              <y>0</y>
-             <width>498</width>
-             <height>850</height>
+             <width>478</width>
+             <height>788</height>
          </rect>
-     </property>
-     <property name="contextMenuPolicy">
-         <enum>Qt::CustomContextMenu</enum>
      </property>
      <property name="floating">
          <bool>false</bool>
@@ -35,7 +32,7 @@
                                  </size>
                              </property>
                              <property name="toolTip">
-                                 <string>Load Snapshot configuration from project</string>
+                                 <string>Load Snapshot configuration from project...</string>
                              </property>
                              <property name="text">
                                  <string/>
@@ -297,7 +294,38 @@
                                          <bool>true</bool>
                                      </property>
                                      <layout class="QGridLayout" name="gridLayout">
-                                         <item row="4" column="0">
+                                         <item row="8" column="1">
+                                             <layout class="QGridLayout" name="gridLayout_2">
+                                                 <item row="1" column="1">
+                                                     <widget class="QLabel" name="label">
+                                                         <property name="text">
+                                                             <string>Precision</string>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item row="1" column="0">
+                                                     <widget class="QLineEdit" name="le_extent"/>
+                                                 </item>
+                                                 <item row="3" column="1" colspan="2">
+                                                     <widget class="QPushButton" name="btn_calculate_extent">
+                                                         <property name="text">
+                                                             <string>Calculate bounds</string>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item row="2" column="1" colspan="2">
+                                                     <widget class="QCheckBox" name="cb_crop_layers">
+                                                         <property name="text">
+                                                             <string>Crop layers</string>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item row="1" column="2">
+                                                     <widget class="QSpinBox" name="sb_extent_precision"/>
+                                                 </item>
+                                             </layout>
+                                         </item>
+                                         <item row="3" column="0">
                                              <widget class="QLabel" name="label_21">
                                                  <property name="font">
                                                      <font>
@@ -310,93 +338,8 @@
                                                  </property>
                                              </widget>
                                          </item>
-                                         <item row="2" column="0">
-                                             <widget class="QLabel" name="label_14">
-                                                 <property name="text">
-                                                     <string>Description</string>
-                                                 </property>
-                                             </widget>
-                                         </item>
-                                         <item row="0" column="1">
-                                             <widget class="QLineEdit" name="input_name"/>
-                                         </item>
-                                         <item row="1" column="1">
-                                             <widget class="QLineEdit" name="input_title"/>
-                                         </item>
-                                         <item row="7" column="0">
-                                             <widget class="QLabel" name="label_15">
-                                                 <property name="text">
-                                                     <string>Bounds</string>
-                                                 </property>
-                                             </widget>
-                                         </item>
                                          <item row="2" column="1">
                                              <widget class="QTextEdit" name="input_description"/>
-                                         </item>
-                                         <item row="1" column="0">
-                                             <widget class="QLabel" name="label_16">
-                                                 <property name="text">
-                                                     <string>Title</string>
-                                                 </property>
-                                             </widget>
-                                         </item>
-                                         <item row="5" column="1">
-                                             <layout class="QHBoxLayout" name="horizontalLayout_6">
-                                                 <item>
-                                                     <widget class="QPushButton" name="btn_add_source_row">
-                                                         <property name="toolTip">
-                                                             <string>Add row</string>
-                                                         </property>
-                                                         <property name="text">
-                                                             <string/>
-                                                         </property>
-                                                     </widget>
-                                                 </item>
-                                                 <item>
-                                                     <spacer name="horizontalSpacer_5">
-                                                         <property name="orientation">
-                                                             <enum>Qt::Horizontal</enum>
-                                                         </property>
-                                                         <property name="sizeHint" stdset="0">
-                                                             <size>
-                                                                 <width>40</width>
-                                                                 <height>20</height>
-                                                             </size>
-                                                         </property>
-                                                     </spacer>
-                                                 </item>
-                                             </layout>
-                                         </item>
-                                         <item row="7" column="1">
-                                             <layout class="QGridLayout" name="gridLayout_2">
-                                                 <item row="0" column="0">
-                                                     <widget class="QLineEdit" name="le_extent"/>
-                                                 </item>
-                                                 <item row="0" column="2">
-                                                     <widget class="QSpinBox" name="sb_extent_precision"/>
-                                                 </item>
-                                                 <item row="2" column="1" colspan="2">
-                                                     <widget class="QPushButton" name="btn_calculate_extent">
-                                                         <property name="text">
-                                                             <string>Calculate bounds</string>
-                                                         </property>
-                                                     </widget>
-                                                 </item>
-                                                 <item row="0" column="1">
-                                                     <widget class="QLabel" name="label">
-                                                         <property name="text">
-                                                             <string>Precision</string>
-                                                         </property>
-                                                     </widget>
-                                                 </item>
-                                                 <item row="1" column="1" colspan="2">
-                                                     <widget class="QCheckBox" name="cb_crop_layers">
-                                                         <property name="text">
-                                                             <string>Crop layers</string>
-                                                         </property>
-                                                     </widget>
-                                                 </item>
-                                             </layout>
                                          </item>
                                          <item row="0" column="0">
                                              <widget class="QLabel" name="label_20">
@@ -411,7 +354,10 @@
                                                  </property>
                                              </widget>
                                          </item>
-                                         <item row="4" column="1">
+                                         <item row="1" column="1">
+                                             <widget class="QLineEdit" name="input_title"/>
+                                         </item>
+                                         <item row="3" column="1">
                                              <layout class="QGridLayout" name="source_grid"
                                                      columnminimumwidth="0,150,0">
                                                  <item row="0" column="1">
@@ -450,8 +396,59 @@
                                                  </property>
                                              </widget>
                                          </item>
-                                         <item row="3" column="0">
-                                             <widget class="QLabel" name="label_22">
+                                         <item row="2" column="0">
+                                             <widget class="QLabel" name="label_14">
+                                                 <property name="text">
+                                                     <string>Description</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="4" column="1">
+                                             <layout class="QHBoxLayout" name="horizontalLayout_6">
+                                                 <item>
+                                                     <widget class="QPushButton" name="btn_add_source_row">
+                                                         <property name="toolTip">
+                                                             <string>Add row</string>
+                                                         </property>
+                                                         <property name="text">
+                                                             <string/>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                                 <item>
+                                                     <spacer name="horizontalSpacer_5">
+                                                         <property name="orientation">
+                                                             <enum>Qt::Horizontal</enum>
+                                                         </property>
+                                                         <property name="sizeHint" stdset="0">
+                                                             <size>
+                                                                 <width>40</width>
+                                                                 <height>20</height>
+                                                             </size>
+                                                         </property>
+                                                     </spacer>
+                                                 </item>
+                                             </layout>
+                                         </item>
+                                         <item row="1" column="0">
+                                             <widget class="QLabel" name="label_16">
+                                                 <property name="text">
+                                                     <string>Title</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="0" column="1">
+                                             <widget class="QLineEdit" name="input_name"/>
+                                         </item>
+                                         <item row="8" column="0">
+                                             <widget class="QLabel" name="label_15">
+                                                 <property name="text">
+                                                     <string>Bounds</string>
+                                                 </property>
+                                             </widget>
+                                         </item>
+                                         <item row="7" column="0">
+                                             <widget class="QLabel" name="label_17">
                                                  <property name="font">
                                                      <font>
                                                          <weight>75</weight>
@@ -459,36 +456,48 @@
                                                      </font>
                                                  </property>
                                                  <property name="text">
-                                                     <string>Keywords</string>
+                                                     <string>License</string>
                                                  </property>
                                              </widget>
                                          </item>
-                                         <item row="3" column="1">
-                                             <widget class="QTextEdit" name="input_keywords">
-                                                 <property name="contextMenuPolicy">
-                                                     <enum>Qt::PreventContextMenu</enum>
-                                                 </property>
-                                                 <property name="autoFormatting">
-                                                     <set>QTextEdit::AutoBulletList</set>
-                                                 </property>
-                                                 <property name="html">
-                                                     <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot;
-                                                         &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-                                                         &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot;
-                                                         content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-                                                         p, li { white-space: pre-wrap; }
-                                                         &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot;
-                                                         font-family:'Ubuntu'; font-size:11pt; font-weight:400;
-                                                         font-style:normal;&quot;&gt;
-                                                         &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px;
-                                                         margin-bottom:0px; margin-left:0px; margin-right:0px;
-                                                         -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-                                                     </string>
-                                                 </property>
-                                                 <property name="placeholderText">
-                                                     <string>Add one keyword per row</string>
-                                                 </property>
-                                             </widget>
+                                         <item row="7" column="1">
+                                             <layout class="QHBoxLayout" name="horizontalLayout_4">
+                                                 <item>
+                                                     <spacer name="horizontalSpacer_3">
+                                                         <property name="orientation">
+                                                             <enum>Qt::Horizontal</enum>
+                                                         </property>
+                                                         <property name="sizeHint" stdset="0">
+                                                             <size>
+                                                                 <width>40</width>
+                                                                 <height>20</height>
+                                                             </size>
+                                                         </property>
+                                                     </spacer>
+                                                 </item>
+                                                 <item>
+                                                     <widget class="QComboBox" name="cb_license">
+                                                         <property name="sizePolicy">
+                                                             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                                                                 <horstretch>0</horstretch>
+                                                                 <verstretch>0</verstretch>
+                                                             </sizepolicy>
+                                                         </property>
+                                                         <property name="maximumSize">
+                                                             <size>
+                                                                 <width>300</width>
+                                                                 <height>16777215</height>
+                                                             </size>
+                                                         </property>
+                                                         <property name="sizeAdjustPolicy">
+                                                             <enum>QComboBox::AdjustToContents</enum>
+                                                         </property>
+                                                         <property name="minimumContentsLength">
+                                                             <number>4</number>
+                                                         </property>
+                                                     </widget>
+                                                 </item>
+                                             </layout>
                                          </item>
                                      </layout>
                                  </widget>

--- a/SpatialDataPackageExport/test/conftest.py
+++ b/SpatialDataPackageExport/test/conftest.py
@@ -21,6 +21,7 @@ import tempfile
 import pytest
 from qgis.core import QgsProject, QgsVectorLayer, QgsVectorDataProvider
 
+from ..model.snapshot import License
 from ..qgis_plugin_tools.testing.utilities import get_qgis_app
 from ..qgis_plugin_tools.tools.resources import plugin_test_data_path
 
@@ -120,6 +121,12 @@ def layer_empty_lines(tmp_dir, layer_lines):
     layer.setCrs(dp.crs())
     verify_layer_copy(layer, layer_lines)
     return layer
+
+
+@pytest.fixture
+def odc_1_0_license():
+    return License("https://opendatacommons.org/licenses/by/1.0/", "ODC-By-1.0",
+                   "Open Data Commons Attribution License")
 
 
 # Helper functions

--- a/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
+++ b/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
@@ -9,11 +9,13 @@
     "topic": "GEMEINDESCAN TOPIC"
   },
   "format": "geojson",
-  "licenses": {
-    "type": "ODC-By-1.0",
-    "url": "https://opendatacommons.org/licenses/by/1.0/",
-    "title": "Open Data Commons Attribution License"
-  },
+  "licenses": [
+    {
+      "type": "ODC-By-1.0",
+      "url": "https://opendatacommons.org/licenses/by/1.0/",
+      "title": "Open Data Commons Attribution License"
+    }
+  ],
   "keywords": [
     "KEYWORD 1",
     "KEYWORD 2",

--- a/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
+++ b/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
@@ -9,11 +9,19 @@
     "topic": "GEMEINDESCAN TOPIC"
   },
   "format": "geojson",
-  "license": "ODC-By-1.0",
+  "license": "Open Data Commons Open Database License",
   "licenses": [
     {
       "url": "https://opendatacommons.org/licenses/by/1.0/",
       "type": "ODC-By-1.0"
+    },
+    {
+      "type": "Creative Commons CC Zero",
+      "url": "https://creativecommons.org/share-your-work/public-domain/cc0/"
+    },
+    {
+      "type": "Creative Commons Attribution Share-Alike 4.0",
+      "url": "https://creativecommons.org/licenses/by-sa/4.0/"
     }
   ],
   "keywords": [

--- a/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
+++ b/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
@@ -13,7 +13,7 @@
   "licenses": [
     {
       "url": "https://opendatacommons.org/licenses/by/1.0/",
-      "type": "ODC-By-1.0"
+      "type": "Open Data Commons Attribution License"
     },
     {
       "type": "Creative Commons CC Zero",

--- a/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
+++ b/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
@@ -9,21 +9,11 @@
     "topic": "GEMEINDESCAN TOPIC"
   },
   "format": "geojson",
-  "license": "Open Data Commons Open Database License",
-  "licenses": [
-    {
-      "url": "https://opendatacommons.org/licenses/by/1.0/",
-      "type": "Open Data Commons Attribution License"
-    },
-    {
-      "type": "Creative Commons CC Zero",
-      "url": "https://creativecommons.org/share-your-work/public-domain/cc0/"
-    },
-    {
-      "type": "Creative Commons Attribution Share-Alike 4.0",
-      "url": "https://creativecommons.org/licenses/by-sa/4.0/"
-    }
-  ],
+  "licenses": {
+    "type": "ODC-By-1.0",
+    "url": "https://opendatacommons.org/licenses/by/1.0/",
+    "title": "Open Data Commons Attribution License"
+  },
   "keywords": [
     "KEYWORD 1",
     "KEYWORD 2",
@@ -106,6 +96,18 @@
     {
       "name": "asd",
       "mediatype": "application/geo+json",
+      "licenses": [
+        {
+          "title": "Creative Commons CC Zero",
+          "type": "CC0-1.0",
+          "url": "https://creativecommons.org/publicdomain/zero/1.0/"
+        },
+        {
+          "title": "Creative Commons Attribution Share-Alike 4.0",
+          "type": "CC-BY-SA-4.0",
+          "url": "https://creativecommons.org/licenses/by-sa/4.0/"
+        }
+      ],
       "data": {
         "type": "FeatureCollection",
         "name": "asd",
@@ -234,6 +236,7 @@
     },
     {
       "name": "mapbox-background",
+      "licenses": [],
       "mediatype": "application/vnd.mapbox-vector-tile",
       "path": "mapbox://styles/gemeindescan/ck6rp249516tg1iqkmt48o4pz"
     }

--- a/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
+++ b/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
@@ -9,11 +9,11 @@
     "topic": "Sample"
   },
   "format": "geojson",
-  "license": "ODC-By-1.0",
+  "license": "Open Data Commons Attribution License",
   "licenses": [
     {
       "url": "https://opendatacommons.org/licenses/by/1.0/",
-      "type": "ODC-By-1.0"
+      "type": "Open Data Commons Attribution License"
     }
   ],
   "keywords": [

--- a/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
+++ b/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
@@ -9,11 +9,13 @@
     "topic": "Sample"
   },
   "format": "geojson",
-  "licenses": {
-    "title": "Open Data Commons Attribution License",
-    "type": "ODC-By-1.0",
-    "url": "https://opendatacommons.org/licenses/by/1.0/"
-  },
+  "licenses": [
+    {
+      "title": "Open Data Commons Attribution License",
+      "type": "ODC-By-1.0",
+      "url": "https://opendatacommons.org/licenses/by/1.0/"
+    }
+  ],
   "keywords": [
     "europe",
     "switzerland",

--- a/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
+++ b/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
@@ -9,13 +9,11 @@
     "topic": "Sample"
   },
   "format": "geojson",
-  "license": "Open Data Commons Attribution License",
-  "licenses": [
-    {
-      "url": "https://opendatacommons.org/licenses/by/1.0/",
-      "type": "Open Data Commons Attribution License"
-    }
-  ],
+  "licenses": {
+    "title": "Open Data Commons Attribution License",
+    "type": "ODC-By-1.0",
+    "url": "https://opendatacommons.org/licenses/by/1.0/"
+  },
   "keywords": [
     "europe",
     "switzerland",
@@ -74,6 +72,7 @@
   "resources": [
     {
       "name": "point-sample-snapshot",
+      "licenses": [],
       "data": {
         "type": "FeatureCollection",
         "name": "point-sample-snapshot",
@@ -159,6 +158,7 @@
     },
     {
       "name": "mapbox-background",
+      "licenses": [],
       "path": "mapbox://styles/gemeindescan/ck6rp249516tg1iqkmt48o4pz",
       "mediatype": "application/vnd.mapbox-vector-tile"
     }

--- a/SpatialDataPackageExport/test/data/snapshots/snapshot_categorized_poly.json
+++ b/SpatialDataPackageExport/test/data/snapshots/snapshot_categorized_poly.json
@@ -9,11 +9,13 @@
     "topic": "GEMEINDESCAN TOPIC"
   },
   "format": "geojson",
-  "licenses": {
-    "url": "https://opendatacommons.org/licenses/by/1.0/",
-    "type": "ODC-By-1.0",
-    "title": "Open Data Commons Attribution License"
-  },
+  "licenses": [
+    {
+      "url": "https://opendatacommons.org/licenses/by/1.0/",
+      "type": "ODC-By-1.0",
+      "title": "Open Data Commons Attribution License"
+    }
+  ],
   "keywords": [
     "KEYWORD 1",
     "KEYWORD 2",

--- a/SpatialDataPackageExport/test/data/snapshots/snapshot_categorized_poly.json
+++ b/SpatialDataPackageExport/test/data/snapshots/snapshot_categorized_poly.json
@@ -9,13 +9,11 @@
     "topic": "GEMEINDESCAN TOPIC"
   },
   "format": "geojson",
-  "license": "ODC-By-1.0",
-  "licenses": [
-    {
-      "url": "https://opendatacommons.org/licenses/by/1.0/",
-      "type": "ODC-By-1.0"
-    }
-  ],
+  "licenses": {
+    "url": "https://opendatacommons.org/licenses/by/1.0/",
+    "type": "ODC-By-1.0",
+    "title": "Open Data Commons Attribution License"
+  },
   "keywords": [
     "KEYWORD 1",
     "KEYWORD 2",
@@ -102,6 +100,13 @@
   "resources": [
     {
       "name": "kolmiot-snapshot",
+      "licenses": [
+        {
+          "url": "https://opendatacommons.org/licenses/by/1.0/",
+          "type": "ODC-By-1.0",
+          "title": "Open Data Commons Attribution License"
+        }
+      ],
       "data": {
         "type": "FeatureCollection",
         "name": "kolmiot-snapshot-snapshot",

--- a/SpatialDataPackageExport/test/test_datapackage.py
+++ b/SpatialDataPackageExport/test/test_datapackage.py
@@ -40,6 +40,7 @@ def test_categorized_poly(new_project, categorized_poly, layer_empty_poly):
     add_layer(layer_empty_poly)
     metadata = layer_empty_poly.metadata()
     metadata.setKeywords({'test': ['kw1', 'kw2'], 'test2': ['kw3']})
+    metadata.setLicenses(['Creative Commons CC Zero', 'Creative Commons Attribution Share-Alike 4.0'])
     layer_empty_poly.setMetadata(metadata)
 
     styled_layer: StyledLayer = StyledLayer('asd', layer_empty_poly.id(), list(converter.legend.values()),
@@ -53,7 +54,7 @@ def test_categorized_poly(new_project, categorized_poly, layer_empty_poly):
     snapshot_config = list(snapshot_config.values())[0]
     snapshot_config.description = 'test description'
     snapshot_config.title = 'test title'
-    snapshot = handler.create_snapshot(name, snapshot_config, [styled_layer])
+    snapshot = handler.create_snapshot(name, snapshot_config, [styled_layer], 'Open Data Commons Open Database License')
     expected_snapshot_dict = get_test_json('snapshots', 'categorized_poly_custom_config.json')
     assert snapshot.to_dict() == expected_snapshot_dict
 

--- a/SpatialDataPackageExport/test/test_datapackage.py
+++ b/SpatialDataPackageExport/test/test_datapackage.py
@@ -31,7 +31,7 @@ from ..model.styled_layer import StyledLayer
 from ..qgis_plugin_tools.tools.resources import plugin_test_data_path
 
 
-def test_categorized_poly(new_project, categorized_poly, layer_empty_poly):
+def test_categorized_poly(new_project, categorized_poly, layer_empty_poly, odc_1_0_license):
     converter = StylesToAttributes(categorized_poly, categorized_poly.name(), QgsProcessingFeedback())
     update_fields(converter, layer_empty_poly)
     layer_empty_poly.startEditing()
@@ -54,7 +54,7 @@ def test_categorized_poly(new_project, categorized_poly, layer_empty_poly):
     snapshot_config = list(snapshot_config.values())[0]
     snapshot_config.description = 'test description'
     snapshot_config.title = 'test title'
-    snapshot = handler.create_snapshot(name, snapshot_config, [styled_layer], 'Open Data Commons Open Database License')
+    snapshot = handler.create_snapshot(name, snapshot_config, [styled_layer], odc_1_0_license)
     expected_snapshot_dict = get_test_json('snapshots', 'categorized_poly_custom_config.json')
     assert snapshot.to_dict() == expected_snapshot_dict
 

--- a/SpatialDataPackageExport/ui/dock_widget.py
+++ b/SpatialDataPackageExport/ui/dock_widget.py
@@ -102,6 +102,12 @@ class ExporterDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.cb_crop_layers.setChecked(Settings.crop_layers.get())
         self.cb_crop_layers.stateChanged.connect(lambda: Settings.crop_layers.set(self.cb_crop_layers.isChecked()))
 
+        self.cb_license: QComboBox
+        self.cb_license.clear()
+        licenses = Settings.licences.get()
+        self.cb_license.addItems(list(licenses.keys()))
+        self.cb_license.setCurrentText(self.data_pkg_handler.snapshot_template.license)
+
         for name, snapshot_config in self.data_pkg_handler.config.snapshots[0].items():
             self.input_name.setText(name)
             self.input_title.setText(snapshot_config.title)
@@ -213,7 +219,8 @@ class ExporterDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         snapshot_config = self.__create_snapshot_config()
         snapshot_name = self.input_name.text()
         styled_layers = [row['styled_layer'] for row in self.layer_rows.values()]
-        snapshot = self.data_pkg_handler.create_snapshot(snapshot_name, snapshot_config, styled_layers)
+        license_ = self.cb_license.currentText()
+        snapshot = self.data_pkg_handler.create_snapshot(snapshot_name, snapshot_config, styled_layers, license_)
 
         output_file = Path(output_path, f'{snapshot_name}.json')
 

--- a/SpatialDataPackageExport/ui/dock_widget.py
+++ b/SpatialDataPackageExport/ui/dock_widget.py
@@ -41,7 +41,7 @@ from ..core.processing.task_runner import TaskWrapper, create_styles_to_attribut
 from ..core.utils import extent_to_datapackage_bounds, datapackage_bounds_to_extent
 from ..definitions.configurable_settings import Settings, LayerFormatOptions
 from ..model.config import SnapshotConfig
-from ..model.snapshot import Legend, Source
+from ..model.snapshot import Legend, Source, License
 from ..model.styled_layer import StyledLayer
 from ..qgis_plugin_tools.tools.custom_logging import bar_msg
 from ..qgis_plugin_tools.tools.decorations import log_if_fails
@@ -106,7 +106,7 @@ class ExporterDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.cb_license.clear()
         licenses = Settings.licences.get()
         self.cb_license.addItems(list(licenses.keys()))
-        self.cb_license.setCurrentText(self.data_pkg_handler.snapshot_template.license)
+        self.cb_license.setCurrentText(self.data_pkg_handler.snapshot_template.licenses.title)
 
         for name, snapshot_config in self.data_pkg_handler.config.snapshots[0].items():
             self.input_name.setText(name)
@@ -219,7 +219,10 @@ class ExporterDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         snapshot_config = self.__create_snapshot_config()
         snapshot_name = self.input_name.text()
         styled_layers = [row['styled_layer'] for row in self.layer_rows.values()]
-        license_ = self.cb_license.currentText()
+
+        license_title = self.cb_license.currentText()
+        license_dict = Settings.licences.get().get(license_title)
+        license_ = License(license_dict['url'], license_dict['type'], license_title)
         snapshot = self.data_pkg_handler.create_snapshot(snapshot_name, snapshot_config, styled_layers, license_)
 
         output_file = Path(output_path, f'{snapshot_name}.json')

--- a/SpatialDataPackageExport/ui/dock_widget.py
+++ b/SpatialDataPackageExport/ui/dock_widget.py
@@ -106,7 +106,7 @@ class ExporterDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.cb_license.clear()
         licenses = Settings.licences.get()
         self.cb_license.addItems(list(licenses.keys()))
-        self.cb_license.setCurrentText(self.data_pkg_handler.snapshot_template.licenses.title)
+        self.cb_license.setCurrentText(self.data_pkg_handler.snapshot_template.licenses[0].title)
 
         for name, snapshot_config in self.data_pkg_handler.config.snapshots[0].items():
             self.input_name.setText(name)


### PR DESCRIPTION
This PR utilizes QGIS layer metadata licenses (into `snapshot.licenses`) and allows uses to select license for the whole Snapshot (into `snapshot.license`).

This PR also modifies model by removing `snapshot.license` and adding `License.title`.

WIP:
- [x] rebase after #29 is merged

Resolves #19.