### PR TITLE
Use author of the QGIS project in contributor

### DIFF
--- a/SpatialDataPackageExport/core/datapackage.py
+++ b/SpatialDataPackageExport/core/datapackage.py
@@ -25,12 +25,13 @@ from ..model.config import Config, SnapshotConfig
 from ..model.snapshot import Snapshot, Resource, Legend, License
 from ..model.styled_layer import StyledLayer
 from ..qgis_plugin_tools.tools.resources import plugin_name
-from ..qgis_plugin_tools.tools.settings import get_setting
+from ..qgis_plugin_tools.tools.settings import get_setting, get_project_setting
 
 LOGGER = logging.getLogger(plugin_name())
 
 
 class DataPackageHandler:
+    PROJECT_AUTHOR = 'project_author'
 
     def __init__(self, config: Config, snapshot_template: Snapshot, legend_template: Legend) -> None:
         self.config = config
@@ -96,6 +97,14 @@ class DataPackageHandler:
         confs[snapshot_name] = snapshot_config
         return ProjectSettings.snapshot_configs.set({name: conf.to_dict() for name, conf in confs.items()})
 
+    @staticmethod
+    def get_project_author() -> str:
+        """
+        Get the author of the project
+        :return: Author or the default value
+        """
+        return get_project_setting(DataPackageHandler.PROJECT_AUTHOR, '', internal=False)
+
     def create_snapshot(self, snapshot_name: str, snapshot_config: SnapshotConfig,
                         styled_layers: List[StyledLayer], snapshot_license: Optional[License] = None) -> Snapshot:
         """
@@ -117,6 +126,7 @@ class DataPackageHandler:
         snapshot.gemeindescan_meta = snapshot_config.gemeindescan_meta
         if snapshot_license:
             snapshot.licenses = [snapshot_license]
+        snapshot.contributors[0].title = self.get_project_author()
 
         LOGGER.debug('Updating resources')
         initial_resources = snapshot.resources

--- a/SpatialDataPackageExport/model/snapshot.py
+++ b/SpatialDataPackageExport/model/snapshot.py
@@ -28,8 +28,8 @@ from .model_utils import (from_str, to_class, from_list, from_float, from_union,
 
 class Contributor:
 
-    def __init__(self, web: str, role: str, email: str, title: str) -> None:
-        self.web = web
+    def __init__(self, path: str, role: str, email: str, title: str) -> None:
+        self.path = path
         self.role = role
         self.email = email
         self.title = title
@@ -37,15 +37,15 @@ class Contributor:
     @staticmethod
     def from_dict(obj: Any) -> 'Contributor':
         assert isinstance(obj, dict)
-        web = from_str(obj.get("web"))
+        path = from_str(obj.get("path"))
         role = from_str(obj.get("role"))
         email = from_str(obj.get("email"))
         title = from_str(obj.get("title"))
-        return Contributor(web, role, email, title)
+        return Contributor(path, role, email, title)
 
     def to_dict(self) -> dict:
         result: dict = {}
-        result["web"] = from_str(self.web)
+        result["path"] = from_str(self.path)
         result["role"] = from_str(self.role)
         result["email"] = from_str(self.email)
         result["title"] = from_str(self.title)
@@ -89,26 +89,6 @@ class License:
         result["url"] = from_str(self.url)
         result["type"] = from_str(self.type)
         result["title"] = from_str(self.title)
-        return result
-
-
-class Maintainer:
-
-    def __init__(self, web: str, name: str) -> None:
-        self.web = web
-        self.name = name
-
-    @staticmethod
-    def from_dict(obj: Any) -> 'Maintainer':
-        assert isinstance(obj, dict)
-        web = from_str(obj.get("web"))
-        name = from_str(obj.get("name"))
-        return Maintainer(web, name)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["web"] = from_str(self.web)
-        result["name"] = from_str(self.name)
         return result
 
 
@@ -267,7 +247,7 @@ class Snapshot:
     def __init__(self, name: str, title: str, description: str, version: str, datapackage_version: str,
                  gemeindescan_version: str, gemeindescan_meta: GemeindescanMeta, format: str,
                  licenses: List[License], keywords: List[str], views: List[View], sources: List[Source],
-                 resources: List[Resource], maintainers: List[Maintainer], contributors: List[Contributor]) -> None:
+                 resources: List[Resource], contributors: List[Contributor]) -> None:
         self.name = name
         self.title = title
         self.description = description
@@ -281,7 +261,6 @@ class Snapshot:
         self.views = views
         self.sources = sources
         self.resources = resources
-        self.maintainers = maintainers
         self.contributors = contributors
 
     @staticmethod
@@ -300,10 +279,9 @@ class Snapshot:
         views = from_list(View.from_dict, obj.get("views", []))
         sources = from_list(Source.from_dict, obj.get("sources"))
         resources = from_list(Resource.from_dict, obj.get("resources"))
-        maintainers = from_list(Maintainer.from_dict, obj.get("maintainers"))
         contributors = from_list(Contributor.from_dict, obj.get("contributors"))
         return Snapshot(name, title, description, version, datapackage_version, gemeindescan_version, gemeindescan_meta,
-                        format, licenses, keywords, views, sources, resources, maintainers, contributors)
+                        format, licenses, keywords, views, sources, resources, contributors)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -320,6 +298,5 @@ class Snapshot:
         result["views"] = from_list(lambda x: to_class(View, x), self.views)
         result["sources"] = from_list(lambda x: to_class(Source, x), self.sources)
         result["resources"] = from_list(lambda x: to_class(Resource, x), self.resources)
-        result["maintainers"] = from_list(lambda x: to_class(Maintainer, x), self.maintainers)
         result["contributors"] = from_list(lambda x: to_class(Contributor, x), self.contributors)
         return result

--- a/SpatialDataPackageExport/resources/templates/snapshot-template.json
+++ b/SpatialDataPackageExport/resources/templates/snapshot-template.json
@@ -50,18 +50,12 @@
         "mediatype": "application/vnd.mapbox-vector-tile"
       }
     ],
-    "maintainers": [
-      {
-        "web": "https://github.com/n0rdlicht/",
-        "name": "Thorben Westerhuys"
-      }
-    ],
     "contributors": [
       {
-        "web": "https://cividi.ch",
-        "role": "publisher",
-        "email": "info@cividi.ch",
-        "title": "cividi"
+        "path": "",
+        "role": "author",
+        "email": "",
+        "title": ""
       }
     ]
   },

--- a/SpatialDataPackageExport/test/data/snapshots/categorized_poly.json
+++ b/SpatialDataPackageExport/test/data/snapshots/categorized_poly.json
@@ -235,10 +235,10 @@
   ],
   "contributors": [
     {
-      "web": "https://cividi.ch",
-      "role": "publisher",
-      "email": "info@cividi.ch",
-      "title": "cividi"
+      "path": "",
+      "role": "author",
+      "email": "",
+      "title": ""
     }
   ]
 }

--- a/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
+++ b/SpatialDataPackageExport/test/data/snapshots/categorized_poly_custom_config.json
@@ -243,18 +243,12 @@
       "path": "mapbox://styles/gemeindescan/ck6rp249516tg1iqkmt48o4pz"
     }
   ],
-  "maintainers": [
-    {
-      "web": "https://github.com/n0rdlicht/",
-      "name": "Thorben Westerhuys"
-    }
-  ],
   "contributors": [
     {
-      "web": "https://cividi.ch",
-      "role": "publisher",
-      "email": "info@cividi.ch",
-      "title": "cividi"
+      "path": "",
+      "role": "author",
+      "email": "",
+      "title": "test_author"
     }
   ]
 }

--- a/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
+++ b/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
@@ -165,18 +165,12 @@
       "mediatype": "application/vnd.mapbox-vector-tile"
     }
   ],
-  "maintainers": [
-    {
-      "web": "https://github.com/n0rdlicht/",
-      "name": "Thorben Westerhuys"
-    }
-  ],
   "contributors": [
     {
-      "web": "https://cividi.ch",
-      "role": "publisher",
-      "email": "info@cividi.ch",
-      "title": "cividi"
+      "path": "",
+      "role": "author",
+      "email": "",
+      "title": "test_author"
     }
   ]
 }

--- a/SpatialDataPackageExport/test/data/snapshots/snapshot_categorized_poly.json
+++ b/SpatialDataPackageExport/test/data/snapshots/snapshot_categorized_poly.json
@@ -247,10 +247,10 @@
   ],
   "contributors": [
     {
-      "web": "https://cividi.ch",
-      "role": "publisher",
-      "email": "info@cividi.ch",
-      "title": "cividi"
+      "path": "",
+      "role": "author",
+      "email": "",
+      "title": ""
     }
   ]
 }

--- a/SpatialDataPackageExport/test/test_datapackage.py
+++ b/SpatialDataPackageExport/test/test_datapackage.py
@@ -31,7 +31,14 @@ from ..model.styled_layer import StyledLayer
 from ..qgis_plugin_tools.tools.resources import plugin_test_data_path
 
 
-def test_categorized_poly(new_project, categorized_poly, layer_empty_poly, odc_1_0_license):
+def mock_auth(*args, **kwargs):
+    return 'test_author'
+
+
+def test_categorized_poly(new_project, categorized_poly, layer_empty_poly,odc_1_0_license,  monkeypatch):
+    # Mock get_project_author
+    monkeypatch.setattr(DataPackageHandler, 'get_project_author', mock_auth)
+
     converter = StylesToAttributes(categorized_poly, categorized_poly.name(), QgsProcessingFeedback())
     update_fields(converter, layer_empty_poly)
     layer_empty_poly.startEditing()
@@ -54,12 +61,16 @@ def test_categorized_poly(new_project, categorized_poly, layer_empty_poly, odc_1
     snapshot_config = list(snapshot_config.values())[0]
     snapshot_config.description = 'test description'
     snapshot_config.title = 'test title'
+
     snapshot = handler.create_snapshot(name, snapshot_config, [styled_layer], odc_1_0_license)
     expected_snapshot_dict = get_test_json('snapshots', 'categorized_poly_custom_config.json')
     assert snapshot.to_dict() == expected_snapshot_dict
 
 
-def test_points_with_radius(new_project, points_with_radius, layer_empty_points):
+def test_points_with_radius(new_project, points_with_radius, layer_empty_points, monkeypatch):
+    # Mock get_project_author
+    monkeypatch.setattr(DataPackageHandler, 'get_project_author', mock_auth)
+
     converter = StylesToAttributes(points_with_radius, points_with_radius.name(), QgsProcessingFeedback(),
                                    primary_layer=True)
     update_fields(converter, layer_empty_points)


### PR DESCRIPTION
This PR:
- Remove `snapshot.Maintainer`
- Rename `Contributor.web` -> `Contributor.path`
- Fills `Contributor.title` with author of the QGIS project using newest qgis_plugin_tools (`git submodule update`)

WIP:
- [x] Rebase after #30 is merged


Resolves #20.