### PR TITLE
Improve snapshot configuration saving

### DIFF
--- a/SpatialDataPackageExport/core/datapackage.py
+++ b/SpatialDataPackageExport/core/datapackage.py
@@ -75,26 +75,26 @@ class DataPackageHandler:
         return Config.from_dict(load_json(template_path))
 
     @staticmethod
-    def get_available_settings_from_project() -> Dict[str, SnapshotConfig]:
+    def get_available_settings_from_project() -> Dict[str, Config]:
         """
         Get Snapshot configurations stored in a project
         :return: Available Snapshot configurations
         """
-        existing_confs: Dict[str, SnapshotConfig] = {name: SnapshotConfig.from_dict(config) for name, config in
-                                                     ProjectSettings.snapshot_configs.get().items()}
+        existing_confs: Dict[str, Config] = {name: Config.from_dict(config) for name, config in
+                                             ProjectSettings.snapshot_configs.get().items()}
         return existing_confs
 
     @staticmethod
-    def save_settings_to_project(snapshot_name: str, snapshot_config: SnapshotConfig) -> bool:
+    def save_settings_to_project(snapshot_name: str, config: Config) -> bool:
         """
         Saves snapshot configuration to the project settings
-        :param snapshot_name: Name of the snapshot configuration
-        :param snapshot_config: Snapshot configuration
+        :param snapshot_name: Name of the snapshot
+        :param config: Snapshot configuration
         :return: Whether saving is successful or not
         """
         existing_confs = DataPackageHandler.get_available_settings_from_project()
-        confs = {name: config for name, config in existing_confs.items() if config.title != snapshot_config.title}
-        confs[snapshot_name] = snapshot_config
+        confs = {name: config for name, config in existing_confs.items() if name != snapshot_name}
+        confs[snapshot_name] = config
         return ProjectSettings.snapshot_configs.set({name: conf.to_dict() for name, conf in confs.items()})
 
     @staticmethod

--- a/SpatialDataPackageExport/model/snapshot.py
+++ b/SpatialDataPackageExport/model/snapshot.py
@@ -84,6 +84,10 @@ class License:
         title = from_str(obj.get("title"))
         return License(url, type, title)
 
+    @staticmethod
+    def from_setting(title: str, vals: Dict[str, str]):
+        return License.from_dict({**{'title': title}, **vals})
+
     def to_dict(self) -> dict:
         result: dict = {}
         result["url"] = from_str(self.url)

--- a/SpatialDataPackageExport/resources/templates/export-config.json
+++ b/SpatialDataPackageExport/resources/templates/export-config.json
@@ -1,5 +1,5 @@
 {
-  "project_name": "PROJECT-FOLDER-NAME",
+  "project_name": "",
   "data_dir": "data",
   "snapshots_dir": "snapshots",
   "dp_template_file": "lib/template.json",
@@ -21,14 +21,20 @@
         ],
         "sources": [
           {
-            "url": "SOURCE URL",
-            "title": "SOURCE TITLE/DESCRIPTION"
+            "url": "https://www.openstreetmap.org/copyright",
+            "title": "Karte: Mapbox, \u00a9 OpenStreetMap"
           }
         ],
-        "resources": [
-          "LAYER-01 (as named in QGIS)",
-          "LAYER-02 (as named in QGIS)"
-        ]
+        "resources": [],
+        "licenses": [
+          {
+            "url": "https://opendatacommons.org/licenses/by/1.0/",
+            "type": "ODC-By-1.0",
+            "title": "Open Data Commons Attribution License"
+          }
+        ],
+        "bounds_precision": 8,
+        "crop_layers": true
       }
     }
   ]

--- a/SpatialDataPackageExport/resources/templates/snapshot-template.json
+++ b/SpatialDataPackageExport/resources/templates/snapshot-template.json
@@ -13,19 +13,8 @@
       "bfs_number": 1051
     },
     "format": "geojson",
-    "licenses": [
-      {
-        "url": "https://opendatacommons.org/licenses/by/1.0/",
-        "type": "ODC-By-1.0",
-        "title": "Open Data Commons Attribution License"
-      }
-    ],
-    "keywords": [
-      "europe",
-      "switzerland",
-      "gemeindescan",
-      "geodata"
-    ],
+    "licenses": [],
+    "keywords": [],
     "views": [
       {
         "name": "mapview",
@@ -37,12 +26,7 @@
         }
       }
     ],
-    "sources": [
-      {
-        "url": "https://www.openstreetmap.org/copyright",
-        "title": "Karte: Mapbox, \u00a9 OpenStreetMap"
-      }
-    ],
+    "sources": [],
     "resources": [
       {
         "name": "mapbox-background",

--- a/SpatialDataPackageExport/test/data/config/config_points_with_radius.json
+++ b/SpatialDataPackageExport/test/data/config/config_points_with_radius.json
@@ -28,7 +28,11 @@
           }
         ],
         "resources": [
-          "simple poly"
+          {
+            "name": "simple poly",
+            "primary": false,
+            "shape": "square"
+          }
         ]
       }
     }

--- a/SpatialDataPackageExport/test/data/config/config_simple_poly.json
+++ b/SpatialDataPackageExport/test/data/config/config_simple_poly.json
@@ -26,7 +26,18 @@
           }
         ],
         "resources": [
-          "simple poly"
+          {
+            "name": "simple poly",
+            "primary": false,
+            "shape": "square"
+          }
+        ],
+        "licenses": [
+          {
+            "url": "https://opendatacommons.org/licenses/by/1.0/",
+            "type": "ODC-By-1.0",
+            "title": "Open Data Commons Attribution License"
+          }
         ]
       }
     }

--- a/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
+++ b/SpatialDataPackageExport/test/data/snapshots/points_with_radius.json
@@ -9,13 +9,7 @@
     "topic": "Sample"
   },
   "format": "geojson",
-  "licenses": [
-    {
-      "title": "Open Data Commons Attribution License",
-      "type": "ODC-By-1.0",
-      "url": "https://opendatacommons.org/licenses/by/1.0/"
-    }
-  ],
+  "licenses": [],
   "keywords": [
     "europe",
     "switzerland",

--- a/SpatialDataPackageExport/test/test_datapackage.py
+++ b/SpatialDataPackageExport/test/test_datapackage.py
@@ -102,6 +102,18 @@ def test_styled_layer(tmp_path, points_with_radius):
     assert Path(tmp_path, 'point-sample-snapshot.geojson').exists()
 
 
+def test_config_saving_and_loading(new_project):
+    with open(plugin_test_data_path('config', 'config_simple_poly.json')) as f:
+        config = Config.from_dict(json.load(f))
+    config.snapshots = [{'test': config.get_snapshot_config()}]
+    DataPackageHandler.save_settings_to_project('test', config)
+
+    available_configs = DataPackageHandler.get_available_settings_from_project()
+    assert 'test' in available_configs
+    loaded_conf = available_configs['test']
+    assert loaded_conf.to_dict() == config.to_dict()
+
+
 def update_fields(converter: StylesToAttributes, layer: QgsVectorLayer):
     dp: QgsVectorDataProvider = layer.dataProvider()
     dp.addAttributes(converter.fields)

--- a/SpatialDataPackageExport/test/test_datapackage.py
+++ b/SpatialDataPackageExport/test/test_datapackage.py
@@ -35,7 +35,7 @@ def mock_auth(*args, **kwargs):
     return 'test_author'
 
 
-def test_categorized_poly(new_project, categorized_poly, layer_empty_poly,odc_1_0_license,  monkeypatch):
+def test_categorized_poly(new_project, categorized_poly, layer_empty_poly, odc_1_0_license, monkeypatch):
     # Mock get_project_author
     monkeypatch.setattr(DataPackageHandler, 'get_project_author', mock_auth)
 

--- a/SpatialDataPackageExport/test/test_models.py
+++ b/SpatialDataPackageExport/test/test_models.py
@@ -34,4 +34,11 @@ def test_config_from_template():
     with open(resources_path('templates', 'export-config.json')) as f:
         config_data = json.load(f)
     config = Config.from_dict(config_data)
-    assert config.project_name == 'PROJECT-FOLDER-NAME'
+    assert config.project_name == ''
+    assert len(config.snapshots) == 1
+    snapshot_config = config.snapshots[0]["DATAPACKAGE-FILENAME"]
+    assert snapshot_config.licenses[0].to_dict() == {'title': 'Open Data Commons Attribution License',
+                                                     'type': 'ODC-By-1.0',
+                                                     'url': 'https://opendatacommons.org/licenses/by/1.0/'}
+    assert snapshot_config.bounds_precision == 8
+    assert snapshot_config.crop_layers


### PR DESCRIPTION
This PR:
- Add resources, licenses and bound_precision and crop layers to SnapshotConfig
- Save whole Config instead of just SnapshotConfig
- Save and load more resources from Config

**Warning**: Loading Snapshot configurations from projects saved using previous version is not supported.

Resolves #35.